### PR TITLE
Implement unified retrieve command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@typescript-eslint/eslint-plugin": "^7.1.0",
         "@typescript-eslint/parser": "^7.1.0",
         "eslint": "^8.57.0",
+        "nodemon": "^3.0.2",
         "prettier": "^3.2.5",
         "typescript": "^5.3.3"
       },
@@ -501,6 +502,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -524,6 +539,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -582,6 +610,44 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -1028,6 +1094,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1179,6 +1260,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -1223,6 +1311,19 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1409,6 +1510,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1561,6 +1748,13 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1605,6 +1799,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -1717,6 +1924,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -1804,6 +2024,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -1856,6 +2086,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/src/handlers/clearCache.ts
+++ b/src/handlers/clearCache.ts
@@ -15,7 +15,7 @@ export function handleClearCache(
   const cardId = request.params?.arguments?.card_id as number;
 
   // Validate cache_type parameter
-  const validCacheTypes = ['all', 'cards', 'dashboards', 'individual', 'bulk'];
+  const validCacheTypes = ['all', 'cards', 'dashboards', 'tables', 'databases', 'individual', 'bulk'];
   if (!validCacheTypes.includes(cacheType)) {
     logWarn(`Invalid cache_type parameter: ${cacheType}`, { validTypes: validCacheTypes });
     throw new McpError(
@@ -64,6 +64,18 @@ export function handleClearCache(
       cacheStatus = 'dashboards_cache_empty';
       break;
 
+    case 'tables':
+      apiClient.clearTablesCache();
+      message = 'Tables cache cleared successfully';
+      cacheStatus = 'tables_cache_empty';
+      break;
+
+    case 'databases':
+      apiClient.clearDatabasesCache();
+      message = 'Databases cache cleared successfully';
+      cacheStatus = 'databases_cache_empty';
+      break;
+
     case 'bulk':
       apiClient.clearCardsCache();
       message = 'Cards cache cleared (bulk metadata reset)';
@@ -73,7 +85,7 @@ export function handleClearCache(
     case 'all':
     default:
       apiClient.clearAllCache();
-      message = 'All caches cleared successfully (cards and dashboards)';
+      message = 'All caches cleared successfully (cards, dashboards, tables, and databases)';
       cacheStatus = 'all_caches_empty';
       break;
     }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -5,3 +5,4 @@ export { handleExecuteQuery } from './executeQuery.js';
 export { handleUnifiedSearch } from './unifiedSearch.js';
 export { handleExportQuery } from './exportQuery.js';
 export { handleClearCache } from './clearCache.js';
+export { handleRetrieve } from './retrieve.js';

--- a/src/handlers/retrieve.ts
+++ b/src/handlers/retrieve.ts
@@ -1,0 +1,180 @@
+import { z } from 'zod';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { MetabaseApiClient } from '../api.js';
+import { ErrorCode, McpError } from '../types.js';
+import { handleApiError } from '../utils.js';
+
+// Supported model types for the retrieve command
+type SupportedModel = 'card' | 'dashboard' | 'table' | 'database';
+
+export async function handleRetrieve(
+  request: z.infer<typeof CallToolRequestSchema>,
+  requestId: string,
+  apiClient: MetabaseApiClient,
+  logDebug: (message: string, data?: unknown) => void,
+  logInfo: (message: string, data?: unknown) => void,
+  logWarn: (message: string, data?: unknown, error?: Error) => void,
+  logError: (message: string, data?: unknown) => void
+) {
+  const { model, ids } = request.params?.arguments || {};
+
+  // Validate required parameters
+  if (!model) {
+    logWarn('Missing model parameter in retrieve request', { requestId });
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'Model parameter is required. Must be one of: card, dashboard, table, database'
+    );
+  }
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    logWarn('Missing or invalid ids parameter in retrieve request', { requestId });
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'IDs parameter is required and must be a non-empty array of numbers'
+    );
+  }
+
+  // Validate model type
+  const supportedModels: SupportedModel[] = ['card', 'dashboard', 'table', 'database'];
+  if (!supportedModels.includes(model as SupportedModel)) {
+    logWarn(`Invalid model type: ${model}`, { requestId });
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Invalid model type. Must be one of: ${supportedModels.join(', ')}`
+    );
+  }
+
+  // Validate all IDs are numbers
+  const numericIds: number[] = [];
+  for (const id of ids) {
+    if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) {
+      logWarn(`Invalid ID: ${id}. All IDs must be positive integers`, { requestId });
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid ID: ${id}. All IDs must be positive integers`
+      );
+    }
+    numericIds.push(id);
+  }
+
+  logDebug(`Retrieving ${model} details for IDs: ${numericIds.join(', ')}`);
+
+  try {
+    const startTime = Date.now();
+    const results: any[] = [];
+    const errors: Array<{ id: number; error: string }> = [];
+
+    // Fetch each item individually (Metabase doesn't support bulk retrieval for these endpoints)
+    for (const id of numericIds) {
+      try {
+        let item: any;
+
+        switch (model as SupportedModel) {
+          case 'card':
+            item = await apiClient.getCard(id);
+            break;
+          case 'dashboard':
+            item = await apiClient.getDashboardItems(id);
+            break;
+          case 'table':
+            item = await apiClient.getTable(id);
+            break;
+          case 'database':
+            item = await apiClient.getDatabase(id);
+            break;
+        }
+
+        results.push({
+          id,
+          ...item,
+          retrieved_at: new Date().toISOString()
+        });
+
+        logDebug(`Successfully retrieved ${model} ${id}`);
+      } catch (error: any) {
+        const errorMessage = error?.message || error?.data?.message || 'Unknown error';
+        errors.push({ id, error: errorMessage });
+        logWarn(`Failed to retrieve ${model} ${id}: ${errorMessage}`, { requestId });
+      }
+    }
+
+    const totalTime = Date.now() - startTime;
+    const successCount = results.length;
+    const errorCount = errors.length;
+
+    // Determine data source based on fetch time (approximate)
+    const avgFetchTime = totalTime / numericIds.length;
+    const dataSource = avgFetchTime < 10 ? 'cache' : 'api';
+
+    // Create response object
+    const response: any = {
+      model,
+      request_id: requestId,
+      total_requested: numericIds.length,
+      successful_retrievals: successCount,
+      failed_retrievals: errorCount,
+      data_source: dataSource,
+      total_fetch_time_ms: totalTime,
+      average_fetch_time_ms: Math.round(avgFetchTime),
+      retrieved_at: new Date().toISOString(),
+      results: results
+    };
+
+    // Add errors if any occurred
+    if (errors.length > 0) {
+      response.errors = errors;
+      response.message = `Retrieved ${successCount}/${numericIds.length} ${model}s successfully. ${errorCount} failed.`;
+    } else {
+      response.message = `Successfully retrieved all ${successCount} ${model}(s).`;
+    }
+
+    // Add performance info
+    if (dataSource === 'cache') {
+      response.performance_note = 'Data retrieved primarily from cache (optimal efficiency)';
+    } else {
+      response.performance_note = 'Data retrieved via API calls (now cached for future requests)';
+    }
+
+    // Add usage guidance based on model type
+    switch (model as SupportedModel) {
+      case 'card':
+        response.usage_guidance = 'Use the database_id and dataset_query.native.query with execute_query to run queries. You can modify the SQL as needed.';
+        break;
+      case 'dashboard':
+        response.usage_guidance = 'Dashboard items contain the individual cards/questions within the dashboard. Use get_card_sql to retrieve SQL for specific cards.';
+        break;
+      case 'table':
+        response.usage_guidance = 'Table metadata includes column information, data types, and relationships. Use this data to construct queries against the table.';
+        break;
+      case 'database':
+        response.usage_guidance = 'Database details include connection info and available tables. Use table IDs with the retrieve command to get detailed table metadata.';
+        break;
+    }
+
+    const logMessage = errorCount > 0
+      ? `Retrieved ${successCount}/${numericIds.length} ${model}s (${errorCount} errors, source: ${dataSource}, ${totalTime}ms)`
+      : `Successfully retrieved ${successCount} ${model}s (source: ${dataSource}, ${totalTime}ms)`;
+
+    logInfo(logMessage);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(response, null, 2)
+      }]
+    };
+
+  } catch (error: any) {
+    throw handleApiError(error, {
+      operation: `Retrieve ${model} details`,
+      resourceType: model as string,
+      resourceId: numericIds.join(', '),
+      customMessages: {
+        '400': `Invalid ${model} parameters. Ensure all IDs are valid numbers.`,
+        '404': `One or more ${model}s not found. Check that the IDs are correct and the ${model}s exist.`,
+        '500': `Metabase server error while retrieving ${model}s. The server may be experiencing issues.`
+      }
+    }, logError);
+  }
+}


### PR DESCRIPTION
Add a unified `retrieve` command to fetch detailed Metabase model data (Cards, Dashboards, Tables, Databases, Collections, Fields) with multi-ID support and caching, consolidating existing commands.