### PR TITLE
Migrate from .dxt to .mcpb format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Result:** All quality gates passed! 🎉" >> $GITHUB_STEP_SUMMARY
 
-  dxt-build:
-    name: DXT Extension Build
+  mcpb-build:
+    name: MCPB Extension Build
     runs-on: ubuntu-latest
     needs: [quality-gates]
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
@@ -162,24 +162,24 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Install DXT CLI
-      run: npm install -g @anthropic-ai/dxt
+    - name: Install MCPB CLI
+      run: npm install -g @anthropic-ai/mcpb
 
-    - name: Build DXT packages
+    - name: Build MCPB packages
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
       run: |
-        npm run dxt:build
-        echo "✅ DXT packages built successfully"
-        ls -la *.dxt
+        npm run mcpb:build
+        echo "✅ MCPB packages built successfully"
+        ls -la *.mcpb
 
-    - name: Upload DXT artifacts
+    - name: Upload MCPB artifacts
       if: github.ref == 'refs/heads/master'
       uses: actions/upload-artifact@v4
       with:
-        name: metabase-mcp-dxt-packages
+        name: metabase-mcp-mcpb-packages
         path: |
-          metabase-mcp-api-key.dxt
-          metabase-mcp-session.dxt
+          metabase-mcp-api-key.mcpb
+          metabase-mcp-session.mcpb
         retention-days: 7
 
     - name: Create GitHub Release
@@ -187,24 +187,24 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          metabase-mcp-api-key.dxt
-          metabase-mcp-session.dxt
+          metabase-mcp-api-key.mcpb
+          metabase-mcp-session.mcpb
         generate_release_notes: true
         name: Release ${{ github.ref_name }}
         body: |
           ## Metabase MCP Server ${{ github.ref_name }}
 
-          ### Desktop Extension (DXT) Installation
+          ### MCP Bundle (MCPB) Installation
 
-          Choose the appropriate DXT package for your authentication method:
+          Choose the appropriate MCPB package for your authentication method:
 
           **API Key Authentication (Recommended):**
-          1. Download `metabase-mcp-api-key.dxt` from the assets below
+          1. Download `metabase-mcp-api-key.mcpb` from the assets below
           2. Open the file with Claude Desktop to install
           3. Configure your Metabase URL and API key in Claude Desktop's extension settings
 
           **Session Authentication (Email/Password):**
-          1. Download `metabase-mcp-session.dxt` from the assets below
+          1. Download `metabase-mcp-session.mcpb` from the assets below
           2. Open the file with Claude Desktop to install
           3. Configure your Metabase URL, email, and password in Claude Desktop's extension settings
 
@@ -218,30 +218,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: DXT Build Summary
+    - name: MCPB Build Summary
       run: |
-        echo "## 📦 DXT Extension Build Report" >> $GITHUB_STEP_SUMMARY
+        echo "## 📦 MCPB Extension Build Report" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "| Status | Details |" >> $GITHUB_STEP_SUMMARY
         echo "|--------|---------|" >> $GITHUB_STEP_SUMMARY
         echo "| Manifest | ✅ Valid |" >> $GITHUB_STEP_SUMMARY
         echo "| Build | ✅ Successful |" >> $GITHUB_STEP_SUMMARY
-        if [ -f metabase-mcp-api-key.dxt ]; then
-          API_SIZE=$(ls -lh metabase-mcp-api-key.dxt | awk '{print $5}')
+        if [ -f metabase-mcp-api-key.mcpb ]; then
+          API_SIZE=$(ls -lh metabase-mcp-api-key.mcpb | awk '{print $5}')
           echo "| API Key Package | $API_SIZE |" >> $GITHUB_STEP_SUMMARY
         fi
-        if [ -f metabase-mcp-session.dxt ]; then
-          SESSION_SIZE=$(ls -lh metabase-mcp-session.dxt | awk '{print $5}')
+        if [ -f metabase-mcp-session.mcpb ]; then
+          SESSION_SIZE=$(ls -lh metabase-mcp-session.mcpb | awk '{print $5}')
           echo "| Session Package | $SESSION_SIZE |" >> $GITHUB_STEP_SUMMARY
         fi
         echo "| Artifacts | ✅ Uploaded |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Note:** Both DXT packages (API key and session auth) are available as build artifacts for 7 days." >> $GITHUB_STEP_SUMMARY
+        echo "**Note:** Both MCPB packages (API key and session auth) are available as build artifacts for 7 days." >> $GITHUB_STEP_SUMMARY
 
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [unit-tests, coverage-analysis, quality-gates, dxt-build]
+    needs: [unit-tests, coverage-analysis, quality-gates, mcpb-build]
     if: always()
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ Thumbs.db
 tmp/
 temp/
 
-# DXT package files
-*.dxt
+# MCPB package files
+*.mcpb

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,5 +1,5 @@
-# DXT Package Ignore File
-# Specifies files and patterns to exclude from the DXT package
+# MCPB Package Ignore File
+# Specifies files and patterns to exclude from the MCPB package
 
 # Test files
 *.test.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ npm run dev:watch
 # Single development run
 npm run dev
 
-# Build versioned DXT package
-npm run dxt:build
+# Build versioned MCPB package
+npm run mcpb:build
 ```
 
 ### Code Quality
@@ -118,21 +118,21 @@ CACHE_TTL_MS=600000           # 10 minutes default
 REQUEST_TIMEOUT_MS=600000     # 10 minutes default
 ```
 
-## DXT Package Management
+## MCPB Package Management
 
-The project includes DXT (Desktop Extension) package management for easy distribution.
+The project includes MCPB (MCP Bundle) package management for easy distribution.
 
-### Building DXT Packages
+### Building MCPB Packages
 ```bash
-# Build versioned DXT package
-npm run dxt:build
+# Build versioned MCPB package
+npm run mcpb:build
 
 # Validate manifest structure
-npm run dxt:validate
+npm run mcpb:validate
 ```
 
 ### Platform Compatibility
-The DXT package supports cross-platform deployment:
+The MCPB package supports cross-platform deployment:
 - **macOS** (darwin)
 - **Windows** (win32)  
 - **Linux** (linux)

--- a/README.md
+++ b/README.md
@@ -2,30 +2,30 @@
 
 [![smithery badge](https://smithery.ai/badge/@jerichosequitin/metabase)](https://smithery.ai/server/@jerichosequitin/metabase)
 
-**Version**: 1.0.0
+**Version**: 1.0.1
 
 **Author**: Jericho Sequitin (@jerichosequitin)
 
 A high-performance Model Context Protocol server for AI integration with Metabase analytics platforms. Features intelligent caching, response optimization, and comprehensive data access tools.
 
-**Available as a Desktop Extension (DXT) for Claude Desktop.**
+**Available as an MCP Bundle (MCPB) for Claude Desktop.**
 
 ## Installation Options
 
-#### Option 1: Desktop Extension (Recommended for Claude Desktop Users)
+#### Option 1: MCP Bundle (Recommended for Claude Desktop Users)
 
-1. Download `metabase-mcp.dxt` from [Releases](https://github.com/jerichosequitin/metabase-mcp/releases)
-2. Open the `.dxt` file with Claude Desktop to install
+1. Download `metabase-mcp.mcpb` from [Releases](https://github.com/jerichosequitin/metabase-mcp/releases)
+2. Open the `.mcpb` file with Claude Desktop to install
 3. Configure your Metabase credentials in Claude Desktop's extension settings:
    - **Metabase URL** (required)
    - **Authentication**: Choose either API key OR email/password
    - **Export Directory**: Customize where files are saved (defaults to Downloads/Metabase)
    - **Optional**: Log level, cache TTL, and request timeout settings
 
-##### Benefits of DXT Installation
+##### Benefits of MCP Bundle Installation
 
 - **Single-click installation**: No manual configuration files or command-line setup
-- **Automatic updates**: Claude Desktop manages extension updates
+- **Automatic updates**: Claude Desktop manages bundle updates
 - **User-friendly settings**: Configure through Claude Desktop's UI
 - **Seamless integration**: Tools automatically available in your conversations
 
@@ -280,14 +280,14 @@ npm run test:coverage
 npm run inspector  # MCP Inspector for debugging
 ```
 
-### Building DXT Package
+### Building MCPB Package
 
 ```bash
 # Build for distribution
-npm run dxt:build
+npm run mcpb:build
 ```
 
-Creates `metabase-mcp.dxt` ready for GitHub Releases.
+Creates `metabase-mcp.mcpb` ready for GitHub Releases.
 
 ## Security Considerations
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-  "dxt_version": "0.2.5",
+  "manifest_version": "0.3",
   "name": "metabase-mcp",
   "display_name": "Metabase",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A high-performance MCP server for Metabase analytics data access with intelligent caching and response optimization.",
   "long_description": "This MCP server provides AI assistants with optimized access to Metabase analytics data. It offers high-performance data retrieval with intelligent caching, response optimization, and comprehensive tools for searching, listing, retrieving, and exporting data from Metabase instances. Features include concurrent processing, pagination support, and export capabilities for large datasets. Supports both API key and email/password authentication methods.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jericho/metabase-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A custom Model Context Protocol server for Metabase integration - Jericho's version",
   "private": true,
   "type": "module",
@@ -35,8 +35,8 @@
     "test:coverage": "vitest run --coverage",
     "test:all": "./scripts/test-all.sh",
     "clean": "rm -rf build node_modules/.cache",
-    "dxt:build": "npm run build && node scripts/build-dxt.cjs",
-    "dxt:validate": "echo 'DXT validation - checking manifest structure' && node -e \"const fs = require('fs'); const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8')); console.log('Manifest valid:', manifest.name, manifest.version);\""
+    "mcpb:build": "npm run build && node scripts/build-mcpb.cjs",
+    "mcpb:validate": "echo 'MCPB validation - checking manifest structure' && node -e \"const fs = require('fs'); const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8')); console.log('Manifest valid:', manifest.name, manifest.version);\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.6.1",

--- a/scripts/build-mcpb.cjs
+++ b/scripts/build-mcpb.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Build script for creating DXT package
+ * Build script for creating MCPB package
  */
 
 const fs = require('fs');
@@ -9,11 +9,11 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 function log(message) {
-  console.log(`[DXT Builder] ${message}`);
+  console.log(`[MCPB Builder] ${message}`);
 }
 
-function buildDxtPackage() {
-  log('Building Metabase MCP DXT package...');
+function buildMcpbPackage() {
+  log('Building Metabase MCP MCPB package...');
 
   try {
     const manifestPath = path.join(process.cwd(), 'manifest.json');
@@ -25,14 +25,14 @@ function buildDxtPackage() {
 
     // Read and validate manifest
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    const outputFile = `${manifest.name}-${manifest.version}.dxt`;
+    const outputFile = `${manifest.name}-${manifest.version}.mcpb`;
     log(`Building: ${manifest.name} v${manifest.version}`);
 
-    // Build the DXT package
-    const dxtCommand = `dxt pack . ${outputFile}`;
-    log(`Executing: ${dxtCommand}`);
+    // Build the MCPB package
+    const mcpbCommand = `mcpb pack . ${outputFile}`;
+    log(`Executing: ${mcpbCommand}`);
 
-    execSync(dxtCommand, {
+    execSync(mcpbCommand, {
       stdio: 'inherit',
       cwd: process.cwd()
     });
@@ -42,7 +42,7 @@ function buildDxtPackage() {
     // Verify the file was created
     const outputPath = path.join(process.cwd(), outputFile);
     if (!fs.existsSync(outputPath)) {
-      throw new Error(`DXT file was not created: ${outputFile}`);
+      throw new Error(`MCPB file was not created: ${outputFile}`);
     }
 
     const stats = fs.statSync(outputPath);
@@ -50,14 +50,14 @@ function buildDxtPackage() {
 
     return outputFile;
   } catch (error) {
-    log(`Error building DXT package: ${error.message}`);
+    log(`Error building MCPB package: ${error.message}`);
     throw error;
   }
 }
 
 
 function main() {
-  log('Starting DXT package build process...');
+  log('Starting MCPB package build process...');
 
   // Ensure we're in the project root
   const packageJsonPath = path.join(process.cwd(), 'package.json');
@@ -65,10 +65,10 @@ function main() {
     throw new Error('package.json not found. Please run this script from the project root.');
   }
 
-  // Build the DXT package
-  const outputFile = buildDxtPackage();
+  // Build the MCPB package
+  const outputFile = buildMcpbPackage();
 
-  log('\nDXT package built successfully!');
+  log('\nMCPB package built successfully!');
   log(`Created: ${outputFile}`);
 }
 
@@ -76,9 +76,9 @@ if (require.main === module) {
   try {
     main();
   } catch (error) {
-    console.error(`[DXT Builder] Fatal error: ${error.message}`);
+    console.error(`[MCPB Builder] Fatal error: ${error.message}`);
     process.exit(1);
   }
 }
 
-module.exports = { buildDxtPackage };
+module.exports = { buildMcpbPackage };

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { homedir } from 'os';
 import { join } from 'path';
 
-// Helper function to expand DXT system variables
+// Helper function to expand system variables
 function expandSystemVariables(path: string | undefined): string {
   // If no path is provided, use default
   if (!path) {


### PR DESCRIPTION
## Summary
Migrates the project from deprecated `.dxt` format to the new `.mcpb` (MCP Bundle) format, fixing installation issues in Claude Desktop.

## Critical Changes
- **manifest.json**: `dxt_version: "0.2.5"` → `manifest_version: "0.3"` ⚠️ **Breaking change**
- **Version bump**: `1.0.0` → `1.0.1`

## Files Changed

### Renamed Files
- `.dxtignore` → `.mcpbignore`
- `scripts/build-dxt.cjs` → `scripts/build-mcpb.cjs`

### Updated Files
- `package.json` - Updated scripts: `dxt:build` → `mcpb:build`, `dxt:validate` → `mcpb:validate`
- `.gitignore` - Updated pattern: `*.dxt` → `*.mcpb`
- `README.md` - All references updated, "Desktop Extension" → "MCP Bundle"
- `CLAUDE.md` - Developer documentation updated for MCPB
- `.github/workflows/test.yml` - CI/CD pipeline updated (job name, CLI installation, artifacts)
- `src/config.ts` - Updated code comment

## Why This Change?

Anthropic deprecated the `.dxt` format in favor of `.mcpb` (September 2025). The outdated manifest format (`dxt_version`) was causing installation failures in Claude Desktop. This update:

✅ Fixes installation issues for users  
✅ Aligns with Anthropic's current standards  
✅ Maintains all existing functionality (purely naming convention update)

## Testing
- ✅ Manifest validation passed
- ✅ TypeScript compilation successful
- ✅ All 235 tests passing
- ✅ Pre-commit hooks passed (type-check, lint, format)

## References
- [Anthropic Desktop Extensions Announcement](https://www.anthropic.com/engineering/desktop-extensions)
- File extension changed from .dxt to .mcpb on Sep 11, 2025