### PR TITLE
fix: improve tool error handling and clean up error infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/jerichosequitin/metabase-mcp)
 
-**Version**: 1.1.0
+**Version**: 1.1.1
 
 **Author**: Jericho Sequitin (@jerichosequitin)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "metabase-mcp",
   "display_name": "Metabase",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A high-performance MCP server for Metabase analytics data access with intelligent caching and response optimization.",
   "long_description": "This MCP server provides AI assistants with optimized access to Metabase analytics data. It offers high-performance data retrieval with intelligent caching, response optimization, and comprehensive tools for searching, listing, retrieving, and exporting data from Metabase instances. Features include concurrent processing, pagination support, and export capabilities for large datasets. Supports both API key and email/password authentication methods.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jericho/metabase-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jericho/metabase-mcp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@types/xlsx": "^0.0.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jericho/metabase-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A custom Model Context Protocol server for Metabase integration - Jericho's version",
   "private": true,
   "type": "module",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { config, AuthMethod } from './config.js';
-import { ErrorCode, McpError } from './types/core.js';
+import { ErrorCode, McpError, isMcpError } from './types/core.js';
 import { NetworkErrorFactory, createErrorFromHttpResponse } from './utils/errorFactory.js';
 
 // Logger level enum
@@ -213,7 +213,7 @@ export class MetabaseApiClient {
       }
 
       // If it's already an enhanced McpError, re-throw it
-      if (error instanceof McpError) {
+      if (isMcpError(error)) {
         throw error;
       }
 

--- a/src/handlers/clearCache.ts
+++ b/src/handlers/clearCache.ts
@@ -166,16 +166,6 @@ export function handleClearCache(
       ],
     };
   } catch (error: any) {
-    throw handleApiError(
-      error,
-      {
-        operation: 'Clear cache',
-        customMessages: {
-          // No specific HTTP status codes expected for cache operations
-          // The generic error handling will handle TypeError and other internal errors
-        },
-      },
-      logError
-    );
+    throw handleApiError(error, { operation: 'Clear cache' }, logError);
   }
 }

--- a/src/handlers/execute/executeCard.ts
+++ b/src/handlers/execute/executeCard.ts
@@ -119,19 +119,7 @@ export async function executeCard(
 
     throw handleApiError(
       error,
-      {
-        operation: 'Card execution',
-        resourceType: 'card',
-        resourceId: cardId,
-        customMessages: {
-          '400':
-            "Invalid card parameters or card configuration error. Check that the card exists and all required parameters are provided. If parameter issues persist, consider using execute_query with the card's underlying SQL query instead, which offers more reliable parameter handling.",
-          '404':
-            'Card not found. Verify the card ID exists and you have permission to access it. Alternatively, use execute_query to run the SQL query directly against the database.',
-          '500':
-            "Database server error. The card query may have caused a timeout or database issue. Try using execute_query with the card's SQL query for better error handling and debugging capabilities.",
-        },
-      },
+      { operation: 'Card execution', resourceType: 'card', resourceId: cardId },
       logError
     );
   }

--- a/src/handlers/execute/executeQuery.ts
+++ b/src/handlers/execute/executeQuery.ts
@@ -174,11 +174,6 @@ export async function executeSqlQuery(
         operation: 'SQL query execution',
         resourceType: 'database',
         resourceId: databaseId as number,
-        customMessages: {
-          '400':
-            'Invalid query parameters or SQL syntax error. Check your query syntax and ensure all table/column names are correct.',
-          '500': 'Database server error. The query may have caused a timeout or database issue.',
-        },
       },
       logError
     );

--- a/src/handlers/execute/executeQuery.ts
+++ b/src/handlers/execute/executeQuery.ts
@@ -1,5 +1,9 @@
 import { MetabaseApiClient } from '../../api.js';
-import { handleApiError, validatePositiveInteger } from '../../utils/index.js';
+import {
+  handleApiError,
+  validatePositiveInteger,
+  validateMetabaseResponse,
+} from '../../utils/index.js';
 import { SqlExecutionParams, ExecutionResponse } from './types.js';
 import { optimizeExecuteData } from './optimizers.js';
 import { config } from '../../config.js';
@@ -128,6 +132,13 @@ export async function executeSqlQuery(
       method: 'POST',
       body: JSON.stringify(queryData),
     });
+
+    // Check for embedded errors in the response (Metabase returns 202 with errors for invalid queries)
+    validateMetabaseResponse(
+      response,
+      { operation: 'SQL query execution', resourceId: databaseId },
+      logError
+    );
 
     const rowCount = response?.data?.rows?.length || 0;
     logInfo(

--- a/src/handlers/export/exportCard.ts
+++ b/src/handlers/export/exportCard.ts
@@ -310,21 +310,7 @@ export async function exportCard(
   } catch (error: any) {
     throw handleApiError(
       error,
-      {
-        operation: 'Export card',
-        resourceType: 'card',
-        resourceId: cardId,
-        customMessages: {
-          '400':
-            "Invalid card parameters or export format issue. Ensure format is csv, json, or xlsx. If parameter issues persist, consider using export_query with the card's underlying SQL query instead, which provides more reliable parameter handling and validation.",
-          '404':
-            'Card not found or not accessible. Alternatively, use export_query to export the SQL query results directly from the database.',
-          '413':
-            'Export payload too large. Try reducing the result set size or use query filters. Consider using export_query with LIMIT clauses for better control over result size.',
-          '500':
-            "Server error. The card may have caused a timeout or database issue. Try using export_query with the card's SQL query for better error handling and timeout control.",
-        },
-      },
+      { operation: 'Export card', resourceType: 'card', resourceId: cardId },
       logError
     );
   }

--- a/src/handlers/export/exportQuery.ts
+++ b/src/handlers/export/exportQuery.ts
@@ -1,5 +1,10 @@
 import { MetabaseApiClient } from '../../api.js';
-import { handleApiError, sanitizeFilename, analyzeXlsxContent } from '../../utils/index.js';
+import {
+  handleApiError,
+  sanitizeFilename,
+  analyzeXlsxContent,
+  validateMetabaseResponse,
+} from '../../utils/index.js';
 import { config, authMethod, AuthMethod } from '../../config.js';
 import * as XLSX from 'xlsx';
 import { SqlExportParams, ExportResponse } from './types.js';
@@ -152,6 +157,14 @@ export async function exportSqlQuery(
     try {
       if (format === 'json') {
         responseData = await response.json();
+
+        // Check for embedded errors (Metabase returns 200/202 with errors for invalid queries)
+        validateMetabaseResponse(
+          responseData,
+          { operation: 'SQL query export', resourceId: databaseId },
+          logError
+        );
+
         // JSON export format might have different structures, let's be more flexible
         if (responseData && typeof responseData === 'object') {
           // Try different possible structures for row counting

--- a/src/handlers/export/exportQuery.ts
+++ b/src/handlers/export/exportQuery.ts
@@ -327,17 +327,7 @@ export async function exportSqlQuery(
   } catch (error: any) {
     throw handleApiError(
       error,
-      {
-        operation: 'Export query',
-        resourceType: 'database',
-        resourceId: databaseId,
-        customMessages: {
-          '400':
-            'Invalid query parameters, SQL syntax error, or export format issue. Ensure format is csv, json, or xlsx.',
-          '413': 'Export payload too large. Try reducing the result set size or use query filters.',
-          '500': 'Database server error. The query may have caused a timeout or database issue.',
-        },
-      },
+      { operation: 'Export query', resourceType: 'database', resourceId: databaseId },
       logError
     );
   }

--- a/src/handlers/list/index.ts
+++ b/src/handlers/list/index.ts
@@ -227,15 +227,7 @@ export async function handleList(
   } catch (error: any) {
     throw handleApiError(
       error,
-      {
-        operation: `List ${validatedModel}`,
-        resourceType: validatedModel,
-        customMessages: {
-          '400': `Invalid list parameters. Ensure model type is valid.`,
-          '404': `List endpoint not found for ${validatedModel}. Check that the model type is supported.`,
-          '500': `Metabase server error while listing ${validatedModel}. The server may be experiencing issues.`,
-        },
-      },
+      { operation: `List ${validatedModel}`, resourceType: validatedModel },
       logError
     );
   }

--- a/src/handlers/resources/resourceHandlers.ts
+++ b/src/handlers/resources/resourceHandlers.ts
@@ -1,5 +1,5 @@
 import { generateRequestId } from '../../utils/index.js';
-import { ErrorCode, McpError } from '../../types/core.js';
+import { ErrorCode, McpError, isMcpError } from '../../types/core.js';
 import { MetabaseApiClient } from '../../api.js';
 import {
   optimizeDashboardResource,
@@ -299,7 +299,7 @@ export async function handleReadResource(
     logWarn(`Invalid URI format: ${uri}`, { requestId });
     throw new McpError(ErrorCode.InvalidRequest, `Invalid URI format: ${uri}`);
   } catch (error) {
-    if (error instanceof McpError) {
+    if (isMcpError(error)) {
       throw error;
     }
 

--- a/src/handlers/retrieve/index.ts
+++ b/src/handlers/retrieve/index.ts
@@ -507,11 +507,6 @@ export async function handleRetrieve(
         operation: `Retrieve ${validatedModel} details`,
         resourceType: validatedModel,
         resourceId: numericIds.join(', '),
-        customMessages: {
-          '400': `Invalid ${validatedModel} parameters. Ensure all IDs are valid numbers.`,
-          '404': `One or more ${validatedModel}s not found. Check that the IDs are correct and the ${validatedModel}s exist.`,
-          '500': `Metabase server error while retrieving ${validatedModel}s. The server may be experiencing issues.`,
-        },
       },
       logError
     );

--- a/src/handlers/retrieve/index.ts
+++ b/src/handlers/retrieve/index.ts
@@ -1,6 +1,6 @@
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { MetabaseApiClient, CachedResponse } from '../../api.js';
-import { ErrorCode, McpError } from '../../types/core.js';
+import { ErrorCode, McpError, isMcpError } from '../../types/core.js';
 import {
   ResourceNotFoundErrorFactory,
   AuthorizationErrorFactory,
@@ -300,7 +300,7 @@ export async function handleRetrieve(
         logWarn(`Failed to retrieve ${validatedModel} ${id}: ${errorMessage}`, { requestId });
 
         // Check if this is an enhanced error with specific categories
-        if (error instanceof McpError) {
+        if (isMcpError(error)) {
           return {
             success: false,
             id,

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -15,7 +15,7 @@ export async function handleSearch(
 ) {
   const searchQuery = request.params?.arguments?.query as string;
   const models = (request.params?.arguments?.models as string[]) || ['card', 'dashboard'];
-  const maxResults = (request.params?.arguments?.max_results as number) || 50;
+  const maxResults = (request.params?.arguments?.max_results as number) ?? 20;
   const searchNativeQuery = (request.params?.arguments?.search_native_query as boolean) || false;
   const includeDashboardQuestions =
     (request.params?.arguments?.include_dashboard_questions as boolean) ?? false;
@@ -27,6 +27,10 @@ export async function handleSearch(
   // Validate positive integer parameters
   if (maxResults !== undefined) {
     validatePositiveInteger(maxResults, 'max_results', requestId, logWarn);
+    if (maxResults > 50) {
+      logWarn('max_results exceeds maximum allowed value', { requestId, maxResults });
+      throw new McpError(ErrorCode.InvalidParams, 'max_results must be at most 50');
+    }
   }
   if (databaseId !== undefined) {
     validatePositiveInteger(databaseId, 'database_id', requestId, logWarn);

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -361,12 +361,6 @@ export async function handleSearch(
         operation: 'Search',
         resourceType: databaseId ? 'database' : undefined,
         resourceId: databaseId,
-        customMessages: {
-          '400':
-            'Invalid search parameters. Check model types, database_id, or premium feature requirements (verified parameter).',
-          '403': 'Access denied. You may not have permission to search these items.',
-          '404': 'Search endpoint not found. This Metabase version may not support the search API.',
-        },
       },
       logError
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -202,10 +202,10 @@ export class MetabaseServer {
                 },
                 max_results: {
                   type: 'number',
-                  description: 'Maximum number of results to return (default: 50)',
+                  description: 'Maximum number of results to return (default: 20, max: 50)',
                   minimum: 1,
-                  maximum: 200,
-                  default: 50,
+                  maximum: 50,
+                  default: 20,
                 },
                 search_native_query: {
                   type: 'boolean',

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ export class MetabaseServer {
     this.server = new Server(
       {
         name: 'metabase-mcp',
-        version: '1.1.0',
+        version: '1.1.1',
       },
       {
         capabilities: {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -6,95 +6,14 @@ export enum ErrorCode {
   MethodNotFound = 'method_not_found',
 }
 
-// Enhanced error categories for better agent guidance
-export enum ErrorCategory {
-  AUTHENTICATION = 'authentication',
-  AUTHORIZATION = 'authorization',
-  RESOURCE_NOT_FOUND = 'resource_not_found',
-  VALIDATION = 'validation',
-  RATE_LIMIT = 'rate_limit',
-  TIMEOUT = 'timeout',
-  NETWORK = 'network',
-  DATABASE = 'database',
-  QUERY_EXECUTION = 'query_execution',
-  EXPORT_PROCESSING = 'export_processing',
-  CACHE = 'cache',
-  CONFIGURATION = 'configuration',
-  INTERNAL_SERVER = 'internal_server',
-  EXTERNAL_SERVICE = 'external_service',
-}
-
-// Recovery action recommendations for agents
-export enum RecoveryAction {
-  RETRY_IMMEDIATELY = 'retry_immediately',
-  RETRY_WITH_BACKOFF = 'retry_with_backoff',
-  CHECK_CREDENTIALS = 'check_credentials',
-  VERIFY_PERMISSIONS = 'verify_permissions',
-  VALIDATE_INPUT = 'validate_input',
-  REDUCE_QUERY_COMPLEXITY = 'reduce_query_complexity',
-  USE_SMALLER_DATASET = 'use_smaller_dataset',
-  CHECK_RESOURCE_EXISTS = 'check_resource_exists',
-  CONTACT_ADMIN = 'contact_admin',
-  WAIT_AND_RETRY = 'wait_and_retry',
-  SWITCH_TO_ALTERNATIVE = 'switch_to_alternative',
-  CLEAR_CACHE = 'clear_cache',
-  NO_RETRY = 'no_retry',
-}
-
-// Enhanced error interface with detailed guidance
-export interface ErrorDetails {
-  category: ErrorCategory;
-  httpStatus?: number;
-  metabaseCode?: string;
-  userMessage: string;
-  agentGuidance: string;
-  recoveryAction: RecoveryAction;
-  retryable: boolean;
-  retryAfterMs?: number;
-  additionalContext?: Record<string, unknown>;
-  troubleshootingSteps?: string[];
-}
-
-// Custom error class with enhanced guidance
+// Simple error class for MCP operations
 export class McpError extends Error {
   code: ErrorCode;
-  details: ErrorDetails;
 
-  constructor(code: ErrorCode, message: string, details?: Partial<ErrorDetails>) {
+  constructor(code: ErrorCode, message: string) {
     super(message);
     this.code = code;
     this.name = 'McpError';
-
-    // Set default details if not provided
-    this.details = {
-      category: ErrorCategory.INTERNAL_SERVER,
-      userMessage: message,
-      agentGuidance: 'An unexpected error occurred. Please try again.',
-      recoveryAction: RecoveryAction.RETRY_WITH_BACKOFF,
-      retryable: true,
-      ...details,
-    };
-  }
-
-  // Helper method to create structured error response for agents
-  toAgentResponse(): {
-    error: string;
-    category: string;
-    guidance: string;
-    recoveryAction: string;
-    retryable: boolean;
-    retryAfterMs?: number;
-    troubleshootingSteps?: string[];
-  } {
-    return {
-      error: this.message,
-      category: this.details.category,
-      guidance: this.details.agentGuidance,
-      recoveryAction: this.details.recoveryAction,
-      retryable: this.details.retryable,
-      retryAfterMs: this.details.retryAfterMs,
-      troubleshootingSteps: this.details.troubleshootingSteps,
-    };
   }
 }
 
@@ -107,7 +26,6 @@ export function isMcpError(error: unknown): error is McpError {
     error !== null &&
     typeof error === 'object' &&
     'code' in error &&
-    'details' in error &&
     'message' in error &&
     (error as McpError).name === 'McpError'
   );

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -98,6 +98,21 @@ export class McpError extends Error {
   }
 }
 
+/**
+ * Type guard for McpError that works across ESM module boundaries.
+ * Uses duck typing instead of instanceof to avoid class identity issues.
+ */
+export function isMcpError(error: unknown): error is McpError {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    'details' in error &&
+    'message' in error &&
+    (error as McpError).name === 'McpError'
+  );
+}
+
 // API error type definition
 export interface ApiError {
   status?: number;

--- a/src/utils/errorFactory.ts
+++ b/src/utils/errorFactory.ts
@@ -1,413 +1,151 @@
 /**
- * Error factory utilities for creating specific error instances with detailed guidance
+ * Error factory utilities for creating descriptive error messages
  */
 
-import { ErrorCode, ErrorCategory, RecoveryAction, McpError } from '../types/core.js';
+import { ErrorCode, McpError } from '../types/core.js';
 
 /**
- * Factory for creating authentication-related errors
+ * Authentication error factories
  */
 export class AuthenticationErrorFactory {
-  static invalidCredentials(): McpError {
-    return new McpError(ErrorCode.InvalidParams, 'Authentication failed: Invalid credentials', {
-      category: ErrorCategory.AUTHENTICATION,
-      httpStatus: 401,
-      userMessage: 'Your API key or login credentials are invalid.',
-      agentGuidance:
-        'Verify your Metabase API key or username/password in your configuration. Check the METABASE_API_KEY, METABASE_USER_EMAIL, and METABASE_PASSWORD environment variables.',
-      recoveryAction: RecoveryAction.CHECK_CREDENTIALS,
-      retryable: false,
-      troubleshootingSteps: [
-        'Verify your API key is correct and not expired',
-        'Check that your Metabase URL is correct',
-        'Ensure your user account has the necessary permissions',
-        'Try logging in to Metabase web interface with the same credentials',
-      ],
-    });
+  static invalidCredentials(): Error {
+    return new Error('Authentication failed: Invalid credentials');
   }
 
-  static sessionExpired(): McpError {
-    return new McpError(ErrorCode.InvalidParams, 'Authentication failed: Session expired', {
-      category: ErrorCategory.AUTHENTICATION,
-      httpStatus: 401,
-      userMessage: 'Your session has expired and needs to be renewed.',
-      agentGuidance:
-        'The session token has expired. The system will automatically attempt to re-authenticate. If this persists, check your credentials.',
-      recoveryAction: RecoveryAction.RETRY_IMMEDIATELY,
-      retryable: true,
-      troubleshootingSteps: [
-        'The system will automatically retry authentication',
-        'If retry fails, verify your credentials are still valid',
-        'Check if your account has been locked or disabled',
-      ],
-    });
+  static sessionExpired(): Error {
+    return new Error('Authentication failed: Session expired');
   }
 
-  static invalidApiKey(): McpError {
-    return new McpError(ErrorCode.InvalidParams, 'Authentication failed: Invalid API key', {
-      category: ErrorCategory.AUTHENTICATION,
-      httpStatus: 401,
-      userMessage: 'The provided API key is invalid or has been revoked.',
-      agentGuidance:
-        'Your API key is invalid. Generate a new API key from Metabase Admin > Settings > API Keys.',
-      recoveryAction: RecoveryAction.CHECK_CREDENTIALS,
-      retryable: false,
-      troubleshootingSteps: [
-        'Go to Metabase Admin > Settings > API Keys',
-        'Generate a new API key',
-        'Update your METABASE_API_KEY environment variable',
-        'Ensure the API key has not been revoked or expired',
-      ],
-    });
+  static invalidApiKey(): Error {
+    return new Error('Authentication failed: Invalid API key');
   }
 }
 
 /**
- * Factory for creating authorization-related errors
+ * Authorization error factories
  */
 export class AuthorizationErrorFactory {
-  static insufficientPermissions(resource?: string, action?: string): McpError {
+  static insufficientPermissions(resource?: string, action?: string): Error {
     const resourceMsg = resource ? ` for ${resource}` : '';
     const actionMsg = action ? ` to ${action}` : '';
-
-    return new McpError(
-      ErrorCode.InvalidRequest,
-      `Access denied: Insufficient permissions${resourceMsg}${actionMsg}`,
-      {
-        category: ErrorCategory.AUTHORIZATION,
-        httpStatus: 403,
-        userMessage: `You don't have permission to access this resource${resourceMsg}.`,
-        agentGuidance: `Your user account lacks the necessary permissions${actionMsg}${resourceMsg}. Contact your Metabase administrator to grant appropriate permissions.`,
-        recoveryAction: RecoveryAction.VERIFY_PERMISSIONS,
-        retryable: false,
-        additionalContext: { resource, action },
-        troubleshootingSteps: [
-          'Check your user permissions in Metabase Admin > People',
-          'Verify you have access to the required collections/databases',
-          'Contact your Metabase administrator for permission changes',
-          'Ensure your user group has the necessary permissions',
-        ],
-      }
-    );
+    return new Error(`Access denied: Insufficient permissions${resourceMsg}${actionMsg}`);
   }
 
-  static collectionAccess(collectionId: number): McpError {
-    return new McpError(
-      ErrorCode.InvalidRequest,
-      `Access denied: Cannot access collection ${collectionId}`,
-      {
-        category: ErrorCategory.AUTHORIZATION,
-        httpStatus: 403,
-        userMessage: `You don't have permission to access this collection.`,
-        agentGuidance: `You lack permission to access collection ${collectionId}. This may be a private collection or you may need to be granted access.`,
-        recoveryAction: RecoveryAction.VERIFY_PERMISSIONS,
-        retryable: false,
-        additionalContext: { collectionId },
-        troubleshootingSteps: [
-          'Check if the collection exists and is not archived',
-          'Verify you have been granted access to this collection',
-          'Contact the collection owner or administrator',
-          'Try accessing through a different collection path',
-        ],
-      }
-    );
+  static collectionAccess(collectionId: number): Error {
+    return new Error(`Access denied: Cannot access collection ${collectionId}`);
   }
 }
 
 /**
- * Factory for creating resource not found errors
+ * Resource not found error factories
  */
 export class ResourceNotFoundErrorFactory {
-  static resource(resourceType: string, resourceId: number | string): McpError {
-    return new McpError(ErrorCode.InvalidRequest, `${resourceType} not found: ${resourceId}`, {
-      category: ErrorCategory.RESOURCE_NOT_FOUND,
-      httpStatus: 404,
-      userMessage: `The requested ${resourceType} could not be found.`,
-      agentGuidance: `${resourceType} with ID ${resourceId} does not exist. Verify the ID is correct and the resource hasn't been deleted or archived.`,
-      recoveryAction: RecoveryAction.CHECK_RESOURCE_EXISTS,
-      retryable: false,
-      additionalContext: { resourceType, resourceId },
-      troubleshootingSteps: [
-        `Verify the ${resourceType} ID (${resourceId}) is correct`,
-        `Check if the ${resourceType} has been archived or deleted`,
-        `Use the search tool to find the correct ${resourceType}`,
-        `Verify you have permission to access this ${resourceType}`,
-      ],
-    });
+  static resource(resourceType: string, resourceId: number | string): Error {
+    return new Error(`${resourceType} not found: ${resourceId}`);
   }
 
-  static database(databaseId: number): McpError {
-    return new McpError(ErrorCode.InvalidRequest, `Database not found: ${databaseId}`, {
-      category: ErrorCategory.RESOURCE_NOT_FOUND,
-      httpStatus: 404,
-      userMessage: `The specified database could not be found.`,
-      agentGuidance: `Database with ID ${databaseId} does not exist or is not accessible. Use the 'list' tool with model='databases' to see available databases.`,
-      recoveryAction: RecoveryAction.CHECK_RESOURCE_EXISTS,
-      retryable: false,
-      additionalContext: { databaseId },
-      troubleshootingSteps: [
-        'Use list tool to see available databases',
-        'Verify the database ID is correct',
-        'Check if the database connection is active',
-        'Ensure you have permission to access this database',
-      ],
-    });
+  static database(databaseId: number): Error {
+    return new Error(`Database not found: ${databaseId}`);
   }
 }
 
 /**
- * Factory for creating validation errors
+ * Validation error factories
  */
 export class ValidationErrorFactory {
-  static invalidParameter(parameter: string, value: unknown, expectedFormat?: string): McpError {
-    const formatMsg = expectedFormat ? ` Expected format: ${expectedFormat}` : '';
-
-    return new McpError(ErrorCode.InvalidParams, `Invalid parameter: ${parameter}`, {
-      category: ErrorCategory.VALIDATION,
-      httpStatus: 400,
-      userMessage: `The parameter '${parameter}' has an invalid value.`,
-      agentGuidance: `Parameter '${parameter}' has invalid value '${value}'.${formatMsg} Review the tool's input schema for correct parameter format.`,
-      recoveryAction: RecoveryAction.VALIDATE_INPUT,
-      retryable: false,
-      additionalContext: { parameter, value, expectedFormat },
-      troubleshootingSteps: [
-        'Check the tool documentation for correct parameter format',
-        'Verify the parameter type matches the expected type',
-        'Ensure all required parameters are provided',
-        'Check parameter value constraints (min/max, enum values, etc.)',
-      ],
-    });
+  static invalidParameter(parameter: string, _value: unknown, expectedFormat?: string): McpError {
+    const formatMsg = expectedFormat ? `. Expected: ${expectedFormat}` : '';
+    return new McpError(ErrorCode.InvalidParams, `Invalid parameter: ${parameter}${formatMsg}`);
   }
 
   static cardParameterMismatch(parameterDetails: any): McpError {
     const paramName =
       parameterDetails?.tag?.name || parameterDetails?.tag?.['display-name'] || 'parameter';
-    const submittedValue = parameterDetails?.params?.[0]?.value || 'unknown';
     const expectedType = parameterDetails?.tag?.type || 'unknown';
-
-    return new McpError(ErrorCode.InvalidParams, `Card parameter type mismatch: ${paramName}`, {
-      category: ErrorCategory.VALIDATION,
-      httpStatus: 400,
-      userMessage: `The parameter '${paramName}' has a type mismatch.`,
-      agentGuidance: `Parameter '${paramName}' expects ${expectedType} type but received '${submittedValue}'. Check the parameter type requirements for this card. Consider using execute_query with the card's SQL for more flexible parameter handling.`,
-      recoveryAction: RecoveryAction.VALIDATE_INPUT,
-      retryable: false,
-      additionalContext: {
-        parameterName: paramName,
-        expectedType,
-        submittedValue,
-        parameterDetails,
-      },
-      troubleshootingSteps: [
-        `Verify parameter '${paramName}' value matches expected type: ${expectedType}`,
-        "Check the card's parameter configuration in Metabase",
-        'Use the retrieve tool to get card details and parameter requirements',
-        "Consider using execute_query with the card's SQL for more flexible parameter handling",
-      ],
-    });
+    return new McpError(
+      ErrorCode.InvalidParams,
+      `Card parameter type mismatch: ${paramName} expects ${expectedType}`
+    );
   }
 
-  static sqlSyntaxError(query: string, error: string): McpError {
-    return new McpError(ErrorCode.InvalidRequest, `SQL syntax error: ${error}`, {
-      category: ErrorCategory.QUERY_EXECUTION,
-      httpStatus: 400,
-      userMessage: 'There is a syntax error in your SQL query.',
-      agentGuidance: `SQL query contains syntax errors: ${error}. Review the query for proper SQL syntax and ensure all table/column names are correct.`,
-      recoveryAction: RecoveryAction.VALIDATE_INPUT,
-      retryable: false,
-      additionalContext: { query, sqlError: error },
-      troubleshootingSteps: [
-        'Check SQL syntax for typos and missing keywords',
-        'Verify table and column names exist in the database',
-        'Ensure proper use of quotes around identifiers',
-        'Check for missing commas, parentheses, or other punctuation',
-      ],
-    });
+  static sqlSyntaxError(_query: string, error: string): Error {
+    return new Error(`SQL syntax error: ${error}`);
   }
 }
 
 /**
- * Factory for creating network and timeout errors
+ * Network error factories
  */
 export class NetworkErrorFactory {
-  static timeout(operation: string, timeoutMs: number): McpError {
-    return new McpError(ErrorCode.InternalError, `Operation timed out: ${operation}`, {
-      category: ErrorCategory.TIMEOUT,
-      userMessage: `The operation took too long to complete.`,
-      agentGuidance: `${operation} exceeded the ${timeoutMs}ms timeout. Try reducing the complexity of your request or the amount of data being processed.`,
-      recoveryAction: RecoveryAction.REDUCE_QUERY_COMPLEXITY,
-      retryable: true,
-      retryAfterMs: 5000,
-      additionalContext: { operation, timeoutMs },
-      troubleshootingSteps: [
-        'Reduce the amount of data being queried',
-        'Add more specific filters to your query',
-        'Try splitting large requests into smaller chunks',
-        'Consider using the export tool for large datasets',
-      ],
-    });
+  static timeout(operation: string, timeoutMs: number): Error {
+    return new Error(`Operation timed out: ${operation} (${timeoutMs}ms)`);
   }
 
-  static connectionError(url: string): McpError {
-    return new McpError(ErrorCode.InternalError, `Cannot connect to Metabase server: ${url}`, {
-      category: ErrorCategory.NETWORK,
-      userMessage: 'Unable to connect to the Metabase server.',
-      agentGuidance: `Failed to connect to Metabase at ${url}. Check your network connection and verify the Metabase URL is correct and the server is running.`,
-      recoveryAction: RecoveryAction.WAIT_AND_RETRY,
-      retryable: true,
-      retryAfterMs: 10000,
-      additionalContext: { url },
-      troubleshootingSteps: [
-        'Verify the Metabase URL is correct and accessible',
-        'Check your network connection',
-        'Ensure Metabase server is running and responsive',
-        'Check firewall settings and proxy configurations',
-      ],
-    });
+  static connectionError(url: string): Error {
+    return new Error(`Cannot connect to Metabase server: ${url}`);
   }
 }
 
 /**
- * Factory for creating database and query execution errors
+ * Database error factories
  */
 export class DatabaseErrorFactory {
-  static queryExecutionError(error: string, query?: string): McpError {
-    return new McpError(ErrorCode.InternalError, `Query execution failed: ${error}`, {
-      category: ErrorCategory.QUERY_EXECUTION,
-      httpStatus: 500,
-      userMessage: 'The database query failed to execute.',
-      agentGuidance: `Database query execution failed: ${error}. This may be due to query complexity, database issues, or data access problems.`,
-      recoveryAction: RecoveryAction.REDUCE_QUERY_COMPLEXITY,
-      retryable: true,
-      retryAfterMs: 3000,
-      additionalContext: { query, dbError: error },
-      troubleshootingSteps: [
-        'Simplify the query to reduce complexity',
-        'Check if the database connection is stable',
-        'Verify table and column references are correct',
-        'Try breaking complex queries into smaller parts',
-      ],
-    });
+  static queryExecutionError(error: string, _query?: string): Error {
+    return new Error(`Query execution failed: ${error}`);
   }
 
-  static connectionLost(databaseId: number): McpError {
-    return new McpError(ErrorCode.InternalError, `Database connection lost: ${databaseId}`, {
-      category: ErrorCategory.DATABASE,
-      httpStatus: 503,
-      userMessage: 'Lost connection to the database.',
-      agentGuidance: `Database ${databaseId} connection was lost. The database may be temporarily unavailable or experiencing connectivity issues.`,
-      recoveryAction: RecoveryAction.WAIT_AND_RETRY,
-      retryable: true,
-      retryAfterMs: 15000,
-      additionalContext: { databaseId },
-      troubleshootingSteps: [
-        'Wait for the database connection to be restored',
-        'Check database server status',
-        'Verify database configuration in Metabase',
-        'Contact database administrator if issues persist',
-      ],
-    });
+  static connectionLost(databaseId: number): Error {
+    return new Error(`Database connection lost: ${databaseId}`);
   }
 }
 
 /**
- * Factory for creating rate limiting errors
+ * Rate limit error factories
  */
 export class RateLimitErrorFactory {
-  static exceeded(retryAfterMs?: number): McpError {
-    return new McpError(ErrorCode.InternalError, 'Rate limit exceeded', {
-      category: ErrorCategory.RATE_LIMIT,
-      httpStatus: 429,
-      userMessage: 'Too many requests made in a short time.',
-      agentGuidance:
-        'Rate limit exceeded. Wait before making additional requests. Consider reducing the frequency of your requests.',
-      recoveryAction: RecoveryAction.WAIT_AND_RETRY,
-      retryable: true,
-      retryAfterMs: retryAfterMs || 60000,
-      troubleshootingSteps: [
-        'Wait before making additional requests',
-        'Reduce the frequency of API calls',
-        'Consider batching multiple operations',
-        'Implement exponential backoff for retries',
-      ],
-    });
+  static exceeded(retryAfterMs?: number): Error {
+    const retryMsg = retryAfterMs ? ` Retry after ${retryAfterMs}ms` : '';
+    return new Error(`Rate limit exceeded.${retryMsg}`);
   }
 }
 
 /**
- * Factory for creating export and processing errors
+ * Export error factories
  */
 export class ExportErrorFactory {
-  static fileSizeExceeded(currentSize: number, maxSize: number): McpError {
-    return new McpError(ErrorCode.InvalidRequest, `Export file too large: ${currentSize} bytes`, {
-      category: ErrorCategory.EXPORT_PROCESSING,
-      httpStatus: 413,
-      userMessage: 'The export file is too large to process.',
-      agentGuidance: `Export file size (${currentSize} bytes) exceeds the maximum allowed size (${maxSize} bytes). Use filters to reduce the result set or export in smaller chunks.`,
-      recoveryAction: RecoveryAction.USE_SMALLER_DATASET,
-      retryable: false,
-      additionalContext: { currentSize, maxSize },
-      troubleshootingSteps: [
-        'Add WHERE clauses to filter the data',
-        'Limit the date range of your query',
-        'Select only necessary columns',
-        'Consider exporting data in multiple smaller requests',
-      ],
-    });
+  static fileSizeExceeded(currentSize: number, maxSize: number): Error {
+    return new Error(`Export file too large: ${currentSize} bytes (max: ${maxSize})`);
   }
 
-  static processingFailed(format: string, error: string): McpError {
-    return new McpError(ErrorCode.InternalError, `Export processing failed: ${error}`, {
-      category: ErrorCategory.EXPORT_PROCESSING,
-      httpStatus: 500,
-      userMessage: `Failed to process export in ${format} format.`,
-      agentGuidance: `Export processing failed for ${format} format: ${error}. Try using a different format or reducing the data size.`,
-      recoveryAction: RecoveryAction.SWITCH_TO_ALTERNATIVE,
-      retryable: true,
-      additionalContext: { format, error },
-      troubleshootingSteps: [
-        'Try exporting in a different format (CSV, JSON, XLSX)',
-        'Reduce the amount of data being exported',
-        'Check if the data contains problematic characters',
-        'Verify sufficient disk space for export processing',
-      ],
-    });
+  static processingFailed(format: string, error: string): Error {
+    return new Error(`Export processing failed for ${format}: ${error}`);
   }
 }
 
 /**
- * Utility function to create appropriate error from HTTP response
+ * Create appropriate error from HTTP response status
  */
 export function createErrorFromHttpResponse(
   status: number,
   responseData: any,
-  operation: string,
+  _operation: string,
   resourceType?: string,
   resourceId?: number | string
-): McpError {
+): Error {
   const errorMessage = responseData?.message || responseData?.error || 'HTTP error';
-  // Remove unused operation parameter warning
-  void operation;
 
   switch (status) {
-    case 400: {
-      // Check for Metabase card parameter validation errors
+    case 400:
       if (responseData?.error_type === 'invalid-parameter' && responseData?.['ex-data']) {
         return ValidationErrorFactory.cardParameterMismatch(responseData['ex-data']);
       }
-
       if (
         errorMessage.toLowerCase().includes('sql') ||
         errorMessage.toLowerCase().includes('syntax')
       ) {
         return ValidationErrorFactory.sqlSyntaxError('', errorMessage);
       }
-      return ValidationErrorFactory.invalidParameter(
-        'request',
-        responseData,
-        'Check API documentation'
-      );
-    }
+      return new Error(`Invalid request: ${errorMessage}`);
 
     case 401:
       if (errorMessage.toLowerCase().includes('api key')) {
@@ -428,29 +166,13 @@ export function createErrorFromHttpResponse(
       if (resourceType && resourceId) {
         return ResourceNotFoundErrorFactory.resource(resourceType, resourceId);
       }
-      return new McpError(ErrorCode.InvalidRequest, 'Metabase item not found', {
-        category: ErrorCategory.RESOURCE_NOT_FOUND,
-        httpStatus: 404,
-        userMessage: 'The requested Metabase item could not be found.',
-        agentGuidance:
-          'The requested Metabase item does not exist. Verify the item ID and type are correct, and check that the item has not been archived or deleted.',
-        recoveryAction: RecoveryAction.CHECK_RESOURCE_EXISTS,
-        retryable: false,
-        troubleshootingSteps: [
-          'Verify the item ID is correct',
-          'Check if the item has been archived or deleted',
-          'Use the search tool to find the correct item',
-          'Verify you have permission to access this item',
-        ],
-      });
+      return new Error('Metabase item not found');
 
     case 413:
       return ExportErrorFactory.fileSizeExceeded(0, 0);
 
-    case 429: {
-      const retryAfter = responseData?.retryAfter || 60000;
-      return RateLimitErrorFactory.exceeded(retryAfter);
-    }
+    case 429:
+      return RateLimitErrorFactory.exceeded(responseData?.retryAfter);
 
     case 500:
       if (
@@ -459,39 +181,13 @@ export function createErrorFromHttpResponse(
       ) {
         return DatabaseErrorFactory.queryExecutionError(errorMessage);
       }
-      return new McpError(ErrorCode.InternalError, `Server error: ${errorMessage}`, {
-        category: ErrorCategory.INTERNAL_SERVER,
-        httpStatus: 500,
-        userMessage: 'The server encountered an internal error.',
-        agentGuidance:
-          'Metabase server encountered an internal error. This is typically temporary. Try again in a few moments.',
-        recoveryAction: RecoveryAction.RETRY_WITH_BACKOFF,
-        retryable: true,
-        retryAfterMs: 5000,
-      });
+      return new Error(`Server error: ${errorMessage}`);
 
     case 502:
     case 503:
-      return new McpError(ErrorCode.InternalError, 'Service unavailable', {
-        category: ErrorCategory.EXTERNAL_SERVICE,
-        httpStatus: status,
-        userMessage: 'The Metabase service is temporarily unavailable.',
-        agentGuidance:
-          'Metabase service is temporarily unavailable. This is usually temporary. Wait a few moments and try again.',
-        recoveryAction: RecoveryAction.WAIT_AND_RETRY,
-        retryable: true,
-        retryAfterMs: 30000,
-      });
+      return new Error('Metabase service temporarily unavailable');
 
     default:
-      return new McpError(ErrorCode.InternalError, `HTTP ${status}: ${errorMessage}`, {
-        category: ErrorCategory.EXTERNAL_SERVICE,
-        httpStatus: status,
-        userMessage: 'An unexpected server error occurred.',
-        agentGuidance: `Received HTTP ${status} error: ${errorMessage}. Check the server status and try again.`,
-        recoveryAction: RecoveryAction.RETRY_WITH_BACKOFF,
-        retryable: true,
-        retryAfterMs: 5000,
-      });
+      return new Error(`HTTP ${status}: ${errorMessage}`);
   }
 }

--- a/src/utils/parameterValidation.ts
+++ b/src/utils/parameterValidation.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, McpError } from '../types/core.js';
+import { ErrorCode, McpError, isMcpError } from '../types/core.js';
 import { validateNonEmptyString } from './validation.js';
 
 export interface MetabaseCardParameter {
@@ -46,7 +46,7 @@ export function validateCardParameters(
       validateNonEmptyString(param.slug, `${paramIndex} 'slug' field`, requestId, logWarn);
       validateNonEmptyString(param.type, `${paramIndex} 'type' field`, requestId, logWarn);
     } catch (error) {
-      if (error instanceof McpError) {
+      if (isMcpError(error)) {
         throw new McpError(
           error.code,
           `Card parameter at index ${i} has invalid field: ${error.message}`

--- a/tests/handlers/execute.test.ts
+++ b/tests/handlers/execute.test.ts
@@ -488,7 +488,7 @@ describe('handleExecute (execute command)', () => {
 
       await expect(
         handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
-      ).rejects.toThrow(McpError);
+      ).rejects.toThrow();
     });
   });
 
@@ -643,7 +643,7 @@ describe('handleExecute (execute command)', () => {
 
       await expect(
         handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
-      ).rejects.toThrow(McpError);
+      ).rejects.toThrow();
     });
 
     it('should handle card parameter validation errors with improved error messaging', async () => {
@@ -756,7 +756,7 @@ describe('handleExecute (execute command)', () => {
 
       await expect(
         handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
-      ).rejects.toThrow(McpError);
+      ).rejects.toThrow();
 
       // Verify that parameter validation error was logged
       expect(mockLogger.logError).toHaveBeenCalledWith(

--- a/tests/handlers/list.test.ts
+++ b/tests/handlers/list.test.ts
@@ -105,7 +105,7 @@ describe('handleList', () => {
 
       await expect(
         handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
-      ).rejects.toThrow(McpError);
+      ).rejects.toThrow();
     });
   });
 

--- a/tests/handlers/search.test.ts
+++ b/tests/handlers/search.test.ts
@@ -216,7 +216,7 @@ describe('handleSearch', () => {
 
       await expect(
         handleSearch(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
-      ).rejects.toThrow(McpError);
+      ).rejects.toThrow();
     });
   });
 

--- a/tests/handlers/search.test.ts
+++ b/tests/handlers/search.test.ts
@@ -234,6 +234,34 @@ describe('handleSearch', () => {
       );
     });
 
+    it('should throw error when max_results is 0', async () => {
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+      const request = createMockRequest('search', { query: 'test', max_results: 0 });
+
+      await expect(
+        handleSearch(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        'Invalid max_results parameter - must be a positive number',
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
+
+    it('should throw error when max_results exceeds 50', async () => {
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+      const request = createMockRequest('search', { query: 'test', max_results: 100 });
+
+      await expect(
+        handleSearch(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        'max_results exceeds maximum allowed value',
+        expect.objectContaining({ requestId: 'test-request-id', maxResults: 100 })
+      );
+    });
+
     it('should use search_native_query parameter', async () => {
       const searchResults = [sampleCard];
       mockApiClient.request.mockResolvedValue(searchResults);

--- a/tests/utils/errorFactory.test.ts
+++ b/tests/utils/errorFactory.test.ts
@@ -11,210 +11,126 @@ import {
   createErrorFromHttpResponse,
 } from '../../src/utils/errorFactory.js';
 import { validateMetabaseResponse, extractCleanErrorMessage } from '../../src/utils/errorHandling.js';
-import { ErrorCategory, RecoveryAction, McpError } from '../../src/types/core.js';
+import { McpError } from '../../src/types/core.js';
 
 describe('ErrorFactory', () => {
   describe('AuthenticationErrorFactory', () => {
     it('should create invalid credentials error', () => {
       const error = AuthenticationErrorFactory.invalidCredentials();
-      
       expect(error.message).toBe('Authentication failed: Invalid credentials');
-      expect(error.details.category).toBe(ErrorCategory.AUTHENTICATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.CHECK_CREDENTIALS);
-      expect(error.details.retryable).toBe(false);
-      expect(error.details.troubleshootingSteps).toHaveLength(4);
     });
 
     it('should create session expired error', () => {
       const error = AuthenticationErrorFactory.sessionExpired();
-      
       expect(error.message).toBe('Authentication failed: Session expired');
-      expect(error.details.category).toBe(ErrorCategory.AUTHENTICATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.RETRY_IMMEDIATELY);
-      expect(error.details.retryable).toBe(true);
     });
 
     it('should create invalid API key error', () => {
       const error = AuthenticationErrorFactory.invalidApiKey();
-      
       expect(error.message).toBe('Authentication failed: Invalid API key');
-      expect(error.details.category).toBe(ErrorCategory.AUTHENTICATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.CHECK_CREDENTIALS);
-      expect(error.details.retryable).toBe(false);
     });
   });
 
   describe('AuthorizationErrorFactory', () => {
     it('should create insufficient permissions error', () => {
       const error = AuthorizationErrorFactory.insufficientPermissions('dashboard', 'access');
-      
       expect(error.message).toBe('Access denied: Insufficient permissions for dashboard to access');
-      expect(error.details.category).toBe(ErrorCategory.AUTHORIZATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VERIFY_PERMISSIONS);
-      expect(error.details.retryable).toBe(false);
+    });
+
+    it('should create insufficient permissions error without resource', () => {
+      const error = AuthorizationErrorFactory.insufficientPermissions();
+      expect(error.message).toBe('Access denied: Insufficient permissions');
     });
 
     it('should create collection access error', () => {
       const error = AuthorizationErrorFactory.collectionAccess(123);
-      
       expect(error.message).toBe('Access denied: Cannot access collection 123');
-      expect(error.details.category).toBe(ErrorCategory.AUTHORIZATION);
-      expect(error.details.additionalContext).toEqual({ collectionId: 123 });
     });
   });
 
   describe('ResourceNotFoundErrorFactory', () => {
     it('should create resource not found error', () => {
       const error = ResourceNotFoundErrorFactory.resource('dashboard', 456);
-      
       expect(error.message).toBe('dashboard not found: 456');
-      expect(error.details.category).toBe(ErrorCategory.RESOURCE_NOT_FOUND);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.CHECK_RESOURCE_EXISTS);
-      expect(error.details.retryable).toBe(false);
     });
 
     it('should create database not found error', () => {
       const error = ResourceNotFoundErrorFactory.database(789);
-      
       expect(error.message).toBe('Database not found: 789');
-      expect(error.details.category).toBe(ErrorCategory.RESOURCE_NOT_FOUND);
-      expect(error.details.additionalContext).toEqual({ databaseId: 789 });
     });
   });
 
   describe('ValidationErrorFactory', () => {
     it('should create invalid parameter error', () => {
       const error = ValidationErrorFactory.invalidParameter('card_id', 'invalid', 'Must be a positive integer');
-      
-      expect(error.message).toBe('Invalid parameter: card_id');
-      expect(error.details.category).toBe(ErrorCategory.VALIDATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VALIDATE_INPUT);
-      expect(error.details.retryable).toBe(false);
+      expect(error.message).toBe('Invalid parameter: card_id. Expected: Must be a positive integer');
+    });
+
+    it('should create invalid parameter error without format', () => {
+      const error = ValidationErrorFactory.invalidParameter('limit', -1);
+      expect(error.message).toBe('Invalid parameter: limit');
     });
 
     it('should create SQL syntax error', () => {
       const error = ValidationErrorFactory.sqlSyntaxError('SELECT * FROM', 'Missing table name');
-      
       expect(error.message).toBe('SQL syntax error: Missing table name');
-      expect(error.details.category).toBe(ErrorCategory.QUERY_EXECUTION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VALIDATE_INPUT);
     });
 
     it('should create card parameter mismatch error', () => {
       const parameterDetails = {
-        tag: {
-          id: 'param-id',
-          name: 'user_id',
-          'display-name': 'User ID',
-          type: 'id',
-          dimension: ['template-tag', 'user_id']
-        },
-        type: 'invalid-parameter',
-        params: [
-          {
-            value: 'john_doe',
-            id: 'param-id',
-            type: 'id',
-            target: ['dimension', ['template-tag', 'user_id']],
-            slug: 'user_id'
-          }
-        ]
+        tag: { name: 'user_id', type: 'id' },
+        params: [{ value: 'john_doe' }]
       };
-
       const error = ValidationErrorFactory.cardParameterMismatch(parameterDetails);
-      
-      expect(error.message).toBe('Card parameter type mismatch: user_id');
-      expect(error.details.category).toBe(ErrorCategory.VALIDATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VALIDATE_INPUT);
-      expect(error.details.retryable).toBe(false);
-      expect(error.details.agentGuidance).toContain('Parameter \'user_id\' expects id type but received \'john_doe\'');
-      expect(error.details.troubleshootingSteps).toContain('Verify parameter \'user_id\' value matches expected type: id');
-      expect(error.details.additionalContext).toEqual({
-        parameterName: 'user_id',
-        expectedType: 'id',
-        submittedValue: 'john_doe',
-        parameterDetails
-      });
+      expect(error.message).toBe('Card parameter type mismatch: user_id expects id');
     });
-
   });
 
   describe('NetworkErrorFactory', () => {
     it('should create timeout error', () => {
       const error = NetworkErrorFactory.timeout('Search operation', 30000);
-      
-      expect(error.message).toBe('Operation timed out: Search operation');
-      expect(error.details.category).toBe(ErrorCategory.TIMEOUT);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.REDUCE_QUERY_COMPLEXITY);
-      expect(error.details.retryable).toBe(true);
-      expect(error.details.retryAfterMs).toBe(5000);
+      expect(error.message).toBe('Operation timed out: Search operation (30000ms)');
     });
 
     it('should create connection error', () => {
       const error = NetworkErrorFactory.connectionError('https://example.com');
-      
       expect(error.message).toBe('Cannot connect to Metabase server: https://example.com');
-      expect(error.details.category).toBe(ErrorCategory.NETWORK);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.WAIT_AND_RETRY);
-      expect(error.details.retryable).toBe(true);
     });
   });
 
   describe('DatabaseErrorFactory', () => {
     it('should create query execution error', () => {
-      const error = DatabaseErrorFactory.queryExecutionError('Table not found', 'SELECT * FROM missing_table');
-      
+      const error = DatabaseErrorFactory.queryExecutionError('Table not found');
       expect(error.message).toBe('Query execution failed: Table not found');
-      expect(error.details.category).toBe(ErrorCategory.QUERY_EXECUTION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.REDUCE_QUERY_COMPLEXITY);
-      expect(error.details.retryable).toBe(true);
     });
 
     it('should create connection lost error', () => {
       const error = DatabaseErrorFactory.connectionLost(1);
-      
       expect(error.message).toBe('Database connection lost: 1');
-      expect(error.details.category).toBe(ErrorCategory.DATABASE);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.WAIT_AND_RETRY);
-      expect(error.details.retryable).toBe(true);
     });
   });
 
   describe('RateLimitErrorFactory', () => {
-    it('should create rate limit exceeded error', () => {
+    it('should create rate limit exceeded error with retry time', () => {
       const error = RateLimitErrorFactory.exceeded(120000);
-      
-      expect(error.message).toBe('Rate limit exceeded');
-      expect(error.details.category).toBe(ErrorCategory.RATE_LIMIT);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.WAIT_AND_RETRY);
-      expect(error.details.retryable).toBe(true);
-      expect(error.details.retryAfterMs).toBe(120000);
+      expect(error.message).toBe('Rate limit exceeded. Retry after 120000ms');
     });
 
-    it('should create rate limit exceeded error with default retry time', () => {
+    it('should create rate limit exceeded error without retry time', () => {
       const error = RateLimitErrorFactory.exceeded();
-      
-      expect(error.details.retryAfterMs).toBe(60000);
+      expect(error.message).toBe('Rate limit exceeded.');
     });
   });
 
   describe('ExportErrorFactory', () => {
     it('should create file size exceeded error', () => {
       const error = ExportErrorFactory.fileSizeExceeded(5000000, 1000000);
-      
-      expect(error.message).toBe('Export file too large: 5000000 bytes');
-      expect(error.details.category).toBe(ErrorCategory.EXPORT_PROCESSING);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.USE_SMALLER_DATASET);
-      expect(error.details.retryable).toBe(false);
+      expect(error.message).toBe('Export file too large: 5000000 bytes (max: 1000000)');
     });
 
     it('should create processing failed error', () => {
       const error = ExportErrorFactory.processingFailed('CSV', 'Memory limit exceeded');
-      
-      expect(error.message).toBe('Export processing failed: Memory limit exceeded');
-      expect(error.details.category).toBe(ErrorCategory.EXPORT_PROCESSING);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.SWITCH_TO_ALTERNATIVE);
-      expect(error.details.retryable).toBe(true);
+      expect(error.message).toBe('Export processing failed for CSV: Memory limit exceeded');
     });
   });
 
@@ -225,138 +141,49 @@ describe('ErrorFactory', () => {
         { message: 'SQL syntax error: missing FROM clause' },
         'execute query'
       );
-      
-      expect(error.details.category).toBe(ErrorCategory.QUERY_EXECUTION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VALIDATE_INPUT);
+      expect(error.message).toBe('SQL syntax error: SQL syntax error: missing FROM clause');
     });
 
-    it('should create 400 card parameter mismatch error for invalid-parameter error type', () => {
+    it('should create 400 card parameter mismatch error', () => {
       const responseData = {
         error_type: 'invalid-parameter',
         'ex-data': {
-          tag: {
-            id: 'param-id',
-            name: 'user_id',
-            'display-name': 'User ID',
-            type: 'id',
-            dimension: ['template-tag', 'user_id']
-          },
-          type: 'invalid-parameter',
-          params: [
-            {
-              value: 'john_doe',
-              id: 'param-id',
-              type: 'id',
-              target: ['dimension', ['template-tag', 'user_id']],
-              slug: 'user_id'
-            }
-          ]
+          tag: { name: 'user_id', type: 'id' },
+          params: [{ value: 'john_doe' }]
         }
       };
-
-      const error = createErrorFromHttpResponse(
-        400,
-        responseData,
-        'execute card'
-      );
-      
-      expect(error.message).toBe('Card parameter type mismatch: user_id');
-      expect(error.details.category).toBe(ErrorCategory.VALIDATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VALIDATE_INPUT);
-      expect(error.details.agentGuidance).toContain('Parameter \'user_id\' expects id type but received \'john_doe\'');
+      const error = createErrorFromHttpResponse(400, responseData, 'execute card');
+      expect(error.message).toBe('Card parameter type mismatch: user_id expects id');
     });
 
     it('should create 401 authentication error', () => {
-      const error = createErrorFromHttpResponse(
-        401,
-        { message: 'Invalid API key' },
-        'search cards'
-      );
-      
-      expect(error.details.category).toBe(ErrorCategory.AUTHENTICATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.CHECK_CREDENTIALS);
+      const error = createErrorFromHttpResponse(401, { message: 'Invalid API key' }, 'search cards');
+      expect(error.message).toBe('Authentication failed: Invalid API key');
     });
 
     it('should create 403 authorization error', () => {
-      const error = createErrorFromHttpResponse(
-        403,
-        { message: 'Access denied' },
-        'get dashboard',
-        'dashboard',
-        123
-      );
-      
-      expect(error.details.category).toBe(ErrorCategory.AUTHORIZATION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.VERIFY_PERMISSIONS);
+      const error = createErrorFromHttpResponse(403, { message: 'Access denied' }, 'get dashboard', 'dashboard', 123);
+      expect(error.message).toBe('Access denied: Insufficient permissions for dashboard to access');
     });
 
     it('should create 404 resource not found error', () => {
-      const error = createErrorFromHttpResponse(
-        404,
-        { message: 'Not found' },
-        'get card',
-        'card',
-        456
-      );
-      
-      expect(error.details.category).toBe(ErrorCategory.RESOURCE_NOT_FOUND);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.CHECK_RESOURCE_EXISTS);
+      const error = createErrorFromHttpResponse(404, { message: 'Not found' }, 'get card', 'card', 456);
+      expect(error.message).toBe('card not found: 456');
     });
 
     it('should create 429 rate limit error', () => {
-      const error = createErrorFromHttpResponse(
-        429,
-        { message: 'Rate limit exceeded', retryAfter: 30000 },
-        'search operation'
-      );
-      
-      expect(error.details.category).toBe(ErrorCategory.RATE_LIMIT);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.WAIT_AND_RETRY);
-      expect(error.details.retryAfterMs).toBe(30000);
+      const error = createErrorFromHttpResponse(429, { message: 'Rate limit exceeded', retryAfter: 30000 }, 'search');
+      expect(error.message).toBe('Rate limit exceeded. Retry after 30000ms');
     });
 
     it('should create 500 database error for SQL-related errors', () => {
-      const error = createErrorFromHttpResponse(
-        500,
-        { message: 'Database connection timeout' },
-        'execute query'
-      );
-      
-      expect(error.details.category).toBe(ErrorCategory.QUERY_EXECUTION);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.REDUCE_QUERY_COMPLEXITY);
+      const error = createErrorFromHttpResponse(500, { message: 'Database connection timeout' }, 'execute query');
+      expect(error.message).toBe('Query execution failed: Database connection timeout');
     });
 
     it('should create 503 service unavailable error', () => {
-      const error = createErrorFromHttpResponse(
-        503,
-        { message: 'Service unavailable' },
-        'list cards'
-      );
-      
-      expect(error.details.category).toBe(ErrorCategory.EXTERNAL_SERVICE);
-      expect(error.details.recoveryAction).toBe(RecoveryAction.WAIT_AND_RETRY);
-      expect(error.details.retryAfterMs).toBe(30000);
-    });
-  });
-
-  describe('McpError agent response', () => {
-    it('should create structured agent response', () => {
-      const error = AuthenticationErrorFactory.invalidCredentials();
-      const response = error.toAgentResponse();
-      
-      expect(response.error).toBe(error.message);
-      expect(response.category).toBe(ErrorCategory.AUTHENTICATION);
-      expect(response.guidance).toBe(error.details.agentGuidance);
-      expect(response.recoveryAction).toBe(RecoveryAction.CHECK_CREDENTIALS);
-      expect(response.retryable).toBe(false);
-      expect(response.troubleshootingSteps).toHaveLength(4);
-    });
-
-    it('should include retry time when available', () => {
-      const error = RateLimitErrorFactory.exceeded(60000);
-      const response = error.toAgentResponse();
-      
-      expect(response.retryAfterMs).toBe(60000);
+      const error = createErrorFromHttpResponse(503, { message: 'Service unavailable' }, 'list cards');
+      expect(error.message).toBe('Metabase service temporarily unavailable');
     });
   });
 
@@ -374,11 +201,7 @@ describe('ErrorFactory', () => {
       };
 
       expect(() => {
-        validateMetabaseResponse(
-          successResponse,
-          { operation: 'Test operation', resourceId: 123 },
-          mockLogError
-        );
+        validateMetabaseResponse(successResponse, { operation: 'Test operation', resourceId: 123 }, mockLogError);
       }).not.toThrow();
 
       expect(mockLogError).not.toHaveBeenCalled();
@@ -389,43 +212,20 @@ describe('ErrorFactory', () => {
         error_type: 'invalid-parameter',
         status: 'failed',
         error: 'For input string: "test"',
-        via: [
-          {
-            'ex-data': {
-              tag: {
-                id: 'param-id',
-                name: 'user_id',
-                'display-name': 'User ID',
-                type: 'id',
-                dimension: ['template-tag', 'user_id']
-              },
-              type: 'invalid-parameter',
-              params: [
-                {
-                  value: 'test_value',
-                  id: 'param-id',
-                  type: 'id',
-                  target: ['dimension', ['template-tag', 'user_id']],
-                  slug: 'user_id'
-                }
-              ]
-            }
+        via: [{
+          error_type: 'invalid-parameter',
+          'ex-data': {
+            tag: { name: 'user_id', type: 'id' },
+            params: [{ value: 'test_value' }]
           }
-        ]
+        }]
       };
 
       expect(() => {
-        validateMetabaseResponse(
-          errorResponse,
-          { operation: 'Card execution', resourceId: 123 },
-          mockLogError
-        );
+        validateMetabaseResponse(errorResponse, { operation: 'Card execution', resourceId: 123 }, mockLogError);
       }).toThrow(McpError);
 
-      expect(mockLogError).toHaveBeenCalledWith(
-        'Card execution parameter validation failed for 123',
-        errorResponse
-      );
+      expect(mockLogError).toHaveBeenCalledWith('Card execution parameter validation failed for 123', errorResponse);
     });
 
     it('should throw McpError for invalid-parameter error type with fallback error', () => {
@@ -436,101 +236,32 @@ describe('ErrorFactory', () => {
       };
 
       expect(() => {
-        validateMetabaseResponse(
-          errorResponse,
-          { operation: 'Card execution', resourceId: 456 },
-          mockLogError
-        );
+        validateMetabaseResponse(errorResponse, { operation: 'Card execution', resourceId: 456 }, mockLogError);
       }).toThrowError('Card execution parameter validation failed: Parameter validation failed');
-
-      expect(mockLogError).toHaveBeenCalledWith(
-        'Card execution parameter validation failed for 456',
-        errorResponse
-      );
     });
 
-    it('should throw McpError for other error types with failed status', () => {
+    it('should throw Error for failed status with error message', () => {
       const errorResponse = {
-        error_type: 'database-error',
         status: 'failed',
         error: 'Database connection failed'
       };
 
       expect(() => {
-        validateMetabaseResponse(
-          errorResponse,
-          { operation: 'Query execution' },
-          mockLogError
-        );
-      }).toThrowError('Database connection failed.');
-
-      expect(mockLogError).toHaveBeenCalledWith(
-        'Query execution failed: Database connection failed.',
-        errorResponse
-      );
+        validateMetabaseResponse(errorResponse, { operation: 'Query execution' }, mockLogError);
+      }).toThrowError('Query execution failed: Database connection failed.');
     });
 
-    it('should handle context without resourceId', () => {
+    it('should throw Error for other error types with failed status', () => {
       const errorResponse = {
-        error_type: 'invalid-parameter',
+        error_type: 'database-error',
         status: 'failed',
-        error: 'Invalid parameter'
+        error: 'Database timeout'
       };
 
       expect(() => {
-        validateMetabaseResponse(
-          errorResponse,
-          { operation: 'Search operation' },
-          mockLogError
-        );
-      }).toThrow(McpError);
-
-      expect(mockLogError).toHaveBeenCalledWith(
-        'Search operation parameter validation failed',
-        errorResponse
-      );
+        validateMetabaseResponse(errorResponse, { operation: 'Query execution' }, mockLogError);
+      }).toThrowError('Query execution failed: Database timeout.');
     });
-
-    it('should extract error details from top-level ex-data if via array is not present', () => {
-      const errorResponse = {
-        error_type: 'invalid-parameter',
-        status: 'failed',
-        error: 'Parameter error',
-        'ex-data': {
-          tag: {
-            id: 'param-id',
-            name: 'test_param',
-            'display-name': 'Test Parameter',
-            type: 'text',
-            dimension: ['template-tag', 'test_param']
-          },
-          type: 'invalid-parameter',
-          params: [
-            {
-              value: 'invalid_value',
-              id: 'param-id',
-              type: 'text',
-              target: ['dimension', ['template-tag', 'test_param']],
-              slug: 'test_param'
-            }
-          ]
-        }
-      };
-
-      expect(() => {
-        validateMetabaseResponse(
-          errorResponse,
-          { operation: 'Test operation', resourceId: 789 },
-          mockLogError
-        );
-      }).toThrow(McpError);
-
-      expect(mockLogError).toHaveBeenCalledWith(
-        'Test operation parameter validation failed for 789',
-        errorResponse
-      );
-    });
-
   });
 
   describe('extractCleanErrorMessage', () => {


### PR DESCRIPTION
## Summary
- Return tool errors as results instead of protocol errors (-32603)
- Detect and return query errors from Metabase 202 responses
- Remove unused error metadata infrastructure
- Preserve actual Metabase error messages
- Fix search max_results validation

## Changes

### Error Handling Architecture
- Add `safeCall` wrapper to catch handler errors and return them as `{ isError: true }` tool results
- Prevents MCP SDK from converting thrown errors to JSON-RPC protocol errors

### Metabase 202 Error Detection  
- Detect `status: 'failed'` with `error` field in API responses
- Add `extractCleanErrorMessage()` to clean error messages (removes SQL statements, H2 codes)

### Error Message Preservation
- Remove `customMessages` that were hiding actual Metabase errors
- Simplify `getGenericErrorMessage` to pass through actual error messages
- Add double-prefix detection to avoid "X failed: X failed: ..." messages

### Infrastructure Cleanup
- Remove `ErrorCategory`, `RecoveryAction` enums
- Remove `ErrorDetails` interface and unused metadata fields
- Simplify `McpError` class to just code + message
- Remove `customMessages` from all handlers

### Search Validation
- Fix `max_results=0` silently defaulting to 50 (now throws error)
- Add upper bound validation (max: 50)
- Lower default from 50 to 20 for focused results

## Test plan
- [x] All 274 tests pass
- [x] Type checking passes
- [x] Lint and format checks pass
- [x] Manual testing confirms actual Metabase errors now shown