### PR TITLE
refactor: optimize tool responses and improve error handling

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -212,16 +212,16 @@ export class MetabaseApiClient {
         throw NetworkErrorFactory.connectionError(this.baseUrl);
       }
 
-      // If it's already an enhanced McpError, re-throw it
-      if (isMcpError(error)) {
+      // If it's already an enhanced McpError or Error, re-throw it
+      if (isMcpError(error) || error instanceof Error) {
         throw error;
       }
 
-      // For other errors, wrap in generic network error
+      // For unknown errors, wrap in generic error
       this.logError(`Unexpected error for request to ${path}`, error);
       throw new McpError(
         ErrorCode.InternalError,
-        `Unexpected error during API request: ${error instanceof Error ? error.message : String(error)}`
+        `Unexpected error during API request: ${String(error)}`
       );
     }
   }

--- a/src/handlers/execute/executeQuery.ts
+++ b/src/handlers/execute/executeQuery.ts
@@ -155,7 +155,6 @@ export async function executeSqlQuery(
           text: JSON.stringify(
             {
               success: true,
-              query: limitedQuery, // Use the actual executed query
               database_id: databaseId,
               row_count: rowCount,
               applied_limit: finalLimit,

--- a/src/handlers/execute/index.ts
+++ b/src/handlers/execute/index.ts
@@ -32,7 +32,7 @@ export async function handleExecute(
   const nativeParameters = Array.isArray(args?.native_parameters) ? args.native_parameters : [];
   const cardParameters = Array.isArray(args?.card_parameters) ? args.card_parameters : [];
   const rowLimitArg = args?.row_limit;
-  const rowLimit = typeof rowLimitArg === 'number' ? rowLimitArg : 500;
+  const rowLimit = typeof rowLimitArg === 'number' ? rowLimitArg : 100;
 
   // First validate that parameter types are correct
   if (cardId !== undefined && typeof cardId !== 'number') {
@@ -114,13 +114,13 @@ export async function handleExecute(
     validatePositiveInteger(cardId, 'card_id', requestId, logWarn);
 
     // Validate row limit for cards
-    if (rowLimit < 1 || rowLimit > 2000) {
-      logWarn(`Invalid row_limit parameter: ${rowLimit}. Must be between 1 and 2000.`, {
+    if (rowLimit < 1 || rowLimit > 500) {
+      logWarn(`Invalid row_limit parameter: ${rowLimit}. Must be between 1 and 500.`, {
         requestId,
       });
       throw new McpError(
         ErrorCode.InvalidParams,
-        'Row limit must be between 1 and 2000. For larger datasets, use export_query instead.'
+        'Row limit must be between 1 and 500. For larger datasets, use the export tool instead.'
       );
     }
 
@@ -164,11 +164,11 @@ export async function handleExecute(
   }
 
   // Validate row limit for SQL queries
-  if (rowLimit < 1 || rowLimit > 2000) {
-    logWarn(`Invalid row_limit parameter: ${rowLimit}. Must be between 1 and 2000.`, { requestId });
+  if (rowLimit < 1 || rowLimit > 500) {
+    logWarn(`Invalid row_limit parameter: ${rowLimit}. Must be between 1 and 500.`, { requestId });
     throw new McpError(
       ErrorCode.InvalidParams,
-      'Row limit must be between 1 and 2000. For larger datasets, use export_query instead.'
+      'Row limit must be between 1 and 500. For larger datasets, use the export tool instead.'
     );
   }
 

--- a/src/handlers/execute/optimizers.ts
+++ b/src/handlers/execute/optimizers.ts
@@ -9,7 +9,6 @@
  */
 export interface OptimizedExecuteData {
   [key: string]: any; // Numbered keys like "0", "1", "2" with row objects
-  row_count: number;
 }
 
 /**
@@ -19,11 +18,8 @@ export interface OptimizedExecuteData {
 export function optimizeExecuteData(responseData: any): OptimizedExecuteData {
   const rows = responseData?.rows || [];
   const cols = responseData?.cols || [];
-  const rowCount = rows.length;
 
-  const optimized: OptimizedExecuteData = {
-    row_count: rowCount,
-  };
+  const optimized: OptimizedExecuteData = {};
 
   // Transform each row from array format to object format
   rows.forEach((row: any[], index: number) => {

--- a/src/handlers/export/exportQuery.ts
+++ b/src/handlers/export/exportQuery.ts
@@ -140,11 +140,13 @@ export async function exportSqlQuery(
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      const errorMessage = `Export API request failed with status ${response.status}: ${response.statusText}`;
+      // Extract actual error message from response body, fallback to statusText
+      const actualError = errorData?.message || errorData?.error || response.statusText;
+      const errorMessage = `Export API request failed with status ${response.status}: ${actualError}`;
       logWarn(errorMessage, errorData);
       throw {
         status: response.status,
-        message: response.statusText,
+        message: actualError,
         data: errorData,
       };
     }
@@ -154,47 +156,81 @@ export async function exportSqlQuery(
     let rowCount: number | undefined = 0;
     let fileSize = 0;
 
-    try {
-      if (format === 'json') {
-        responseData = await response.json();
+    if (format === 'json') {
+      responseData = await response.json();
 
-        // Check for embedded errors (Metabase returns 200/202 with errors for invalid queries)
-        validateMetabaseResponse(
-          responseData,
-          { operation: 'SQL query export', resourceId: databaseId },
-          logError
-        );
+      // Check for embedded errors (Metabase returns 200/202 with errors for invalid queries)
+      validateMetabaseResponse(
+        responseData,
+        { operation: 'SQL query export', resourceId: databaseId },
+        logError
+      );
 
-        // JSON export format might have different structures, let's be more flexible
-        if (responseData && typeof responseData === 'object') {
-          // Try different possible structures for row counting
-          rowCount =
-            responseData?.data?.rows?.length ??
-            responseData?.rows?.length ??
-            (Array.isArray(responseData) ? responseData.length : 0);
-        }
-        logDebug(`JSON export row count: ${rowCount}`);
-      } else if (format === 'csv') {
-        responseData = await response.text();
-        // Count rows for CSV (subtract header row)
-        const rows = responseData.split('\n').filter((row: string) => row.trim());
-        rowCount = Math.max(0, rows.length - 1);
-        logDebug(`CSV export row count: ${rowCount}`);
-      } else if (format === 'xlsx') {
-        responseData = await response.arrayBuffer();
-        fileSize = responseData.byteLength;
-
-        // Analyze XLSX content to get accurate row count and data validation
-        const xlsxAnalysis = analyzeXlsxContent(responseData);
-        rowCount = xlsxAnalysis.rowCount;
-
-        logDebug(
-          `XLSX export - file size: ${fileSize} bytes, rows: ${rowCount}, has data: ${xlsxAnalysis.hasData}`
-        );
+      // JSON export format might have different structures, let's be more flexible
+      if (responseData && typeof responseData === 'object') {
+        // Try different possible structures for row counting
+        rowCount =
+          responseData?.data?.rows?.length ??
+          responseData?.rows?.length ??
+          (Array.isArray(responseData) ? responseData.length : 0);
       }
-    } catch (parseError) {
-      logError(`Failed to parse ${format} response: ${parseError}`, parseError);
-      throw new Error(`Failed to parse ${format} response: ${parseError}`);
+      logDebug(`JSON export row count: ${rowCount}`);
+    } else if (format === 'csv') {
+      responseData = await response.text();
+
+      // Check if Metabase returned JSON error instead of CSV (starts with '{')
+      if (responseData.trim().startsWith('{')) {
+        let errorResponse;
+        try {
+          errorResponse = JSON.parse(responseData);
+        } catch {
+          // Not valid JSON, continue with CSV processing
+          errorResponse = null;
+        }
+        if (errorResponse) {
+          validateMetabaseResponse(
+            errorResponse,
+            { operation: 'SQL query export', resourceId: databaseId },
+            logError
+          );
+        }
+      }
+
+      // Count rows for CSV (subtract header row)
+      const rows = responseData.split('\n').filter((row: string) => row.trim());
+      rowCount = Math.max(0, rows.length - 1);
+      logDebug(`CSV export row count: ${rowCount}`);
+    } else if (format === 'xlsx') {
+      responseData = await response.arrayBuffer();
+      fileSize = responseData.byteLength;
+
+      // Check if Metabase returned JSON error instead of XLSX
+      // Valid XLSX files start with PK (ZIP signature), not '{', so check first bytes
+      const textContent = new TextDecoder().decode(responseData);
+      if (textContent.trim().startsWith('{')) {
+        let errorResponse;
+        try {
+          errorResponse = JSON.parse(textContent);
+        } catch {
+          // Not valid JSON, continue with XLSX processing
+          errorResponse = null;
+        }
+        if (errorResponse) {
+          validateMetabaseResponse(
+            errorResponse,
+            { operation: 'SQL query export', resourceId: databaseId },
+            logError
+          );
+        }
+      }
+
+      // Analyze XLSX content to get accurate row count and data validation
+      const xlsxAnalysis = analyzeXlsxContent(responseData);
+      rowCount = xlsxAnalysis.rowCount;
+
+      logDebug(
+        `XLSX export - file size: ${fileSize} bytes, rows: ${rowCount}, has data: ${xlsxAnalysis.hasData}`
+      );
     }
 
     // Validate that we have data before proceeding with file operations
@@ -209,11 +245,7 @@ export async function exportSqlQuery(
             text: JSON.stringify(
               {
                 success: false,
-                message: 'Query executed successfully but returned no data to export',
-                query: query,
-                database_id: databaseId,
-                format: format,
-                row_count: rowCount,
+                error: 'Query returned no data to export',
               },
               null,
               2
@@ -270,19 +302,8 @@ export async function exportSqlQuery(
     if (fileSaveError) {
       const errorResponse: any = {
         success: false,
-        message: 'Export completed but failed to save file',
         error: fileSaveError,
-        query: query,
-        database_id: databaseId,
-        format: format,
-        row_count: rowCount,
-        intended_file_path: savedFilePath,
       };
-
-      // Add file size for all formats
-      if (fileSize > 0) {
-        errorResponse.file_size_bytes = fileSize;
-      }
 
       return {
         content: [
@@ -301,19 +322,10 @@ export async function exportSqlQuery(
     // Successful export - return standardized JSON response
     const successResponse: any = {
       success: true,
-      message: 'Export completed successfully',
-      query: query,
       file_path: savedFilePath,
-      filename: finalFilename,
-      format: format,
       row_count: rowCount,
-      database_id: databaseId,
       file_size_bytes: fileSize,
       preview_data: previewData,
-      preview_note:
-        previewData.length > 0
-          ? `First ${previewData.length} rows shown (${rowCount} total rows exported)`
-          : 'No preview data available',
     };
 
     return {

--- a/src/handlers/list/index.ts
+++ b/src/handlers/list/index.ts
@@ -67,11 +67,9 @@ export async function handleList(
   );
 
   try {
-    const startTime = Date.now();
     let optimizeFunction: (item: any) => any;
     let apiResponse: any;
     let dataSource: 'cache' | 'api';
-    let fetchTime: number;
 
     switch (validatedModel) {
       case 'cards': {
@@ -79,7 +77,6 @@ export async function handleList(
         const cardsResponse = await apiClient.getCardsList();
         apiResponse = cardsResponse.data;
         dataSource = cardsResponse.source;
-        fetchTime = cardsResponse.fetchTime;
         break;
       }
       case 'dashboards': {
@@ -87,7 +84,6 @@ export async function handleList(
         const dashboardsResponse = await apiClient.getDashboardsList();
         apiResponse = dashboardsResponse.data;
         dataSource = dashboardsResponse.source;
-        fetchTime = dashboardsResponse.fetchTime;
         break;
       }
       case 'tables': {
@@ -95,7 +91,6 @@ export async function handleList(
         const tablesResponse = await apiClient.getTablesList();
         apiResponse = tablesResponse.data;
         dataSource = tablesResponse.source;
-        fetchTime = tablesResponse.fetchTime;
         break;
       }
       case 'databases': {
@@ -103,7 +98,6 @@ export async function handleList(
         const databasesResponse = await apiClient.getDatabasesList();
         apiResponse = databasesResponse.data;
         dataSource = databasesResponse.source;
-        fetchTime = databasesResponse.fetchTime;
         break;
       }
       case 'collections': {
@@ -111,7 +105,6 @@ export async function handleList(
         const collectionsResponse = await apiClient.getCollectionsList();
         apiResponse = collectionsResponse.data;
         dataSource = collectionsResponse.source;
-        fetchTime = collectionsResponse.fetchTime;
         break;
       }
       default:
@@ -147,7 +140,6 @@ export async function handleList(
     }
 
     const totalItems = paginatedItems.length;
-    const totalTime = Date.now() - startTime;
 
     logDebug(
       `Successfully fetched ${totalItemsBeforePagination} ${validatedModel}${paginationLimit ? ` (returning ${totalItems} paginated items)` : ''}`
@@ -155,22 +147,9 @@ export async function handleList(
 
     // Create response object
     const response: any = {
-      request_id: requestId,
       model: validatedModel,
       total_items: totalItems,
-      data_source: {
-        source: dataSource,
-        fetch_time_ms: fetchTime,
-        cache_status: dataSource === 'cache' ? 'hit' : 'miss',
-      },
-      performance_metrics: {
-        total_time_ms: totalTime,
-        api_fetch_time_ms: fetchTime,
-        optimization_time_ms: totalTime - fetchTime,
-        average_time_per_item_ms:
-          totalItems > 0 ? Math.round((totalTime - fetchTime) / totalItems) : 0,
-      },
-      retrieved_at: new Date().toISOString(),
+      source: dataSource,
       results: paginatedItems,
     };
 
@@ -178,8 +157,6 @@ export async function handleList(
     if (paginationMetadata) {
       response.pagination = paginationMetadata;
     }
-
-    response.message = `Successfully listed ${totalItems} ${validatedModel} (source: ${dataSource}).`;
 
     // Add usage guidance
     if (paginationLimit !== undefined) {

--- a/src/handlers/prompts/templates/cardExecution.ts
+++ b/src/handlers/prompts/templates/cardExecution.ts
@@ -33,7 +33,7 @@ You must execute this card and return the data. If filter requirements are provi
      "value": "converted-value"
    }]
    \`\`\`
-   Start with row_limit=500.
+   Start with row_limit=100.
 
 3. **Handle failures** by retrying up to 3 times with different parameter value formats or reduced row limits if needed.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -328,7 +328,7 @@ export class MetabaseServer {
           {
             name: 'execute',
             description:
-              'Unified command to execute SQL queries or run saved cards against Metabase databases. Use Card mode when existing cards have the needed filters. Use SQL mode for custom queries or when cards lack required filters. Returns up to 2000 rows per request. SECURITY WARNING: SQL mode can execute ANY valid SQL including destructive operations (DELETE, UPDATE, DROP, TRUNCATE, ALTER). Use with caution and ensure appropriate database permissions are configured in Metabase. Note: When Read-Only Mode is enabled, write operations will be rejected with an error.',
+              'Unified command to execute SQL queries or run saved cards against Metabase databases. Use Card mode when existing cards have the needed filters. Use SQL mode for custom queries or when cards lack required filters. Returns up to 500 rows per request - for larger datasets, use the export tool instead. SECURITY WARNING: SQL mode can execute ANY valid SQL including destructive operations (DELETE, UPDATE, DROP, TRUNCATE, ALTER). Use with caution and ensure appropriate database permissions are configured in Metabase. Note: When Read-Only Mode is enabled, write operations will be rejected with an error.',
             annotations: {
               readOnlyHint: false,
               destructiveHint: true,
@@ -364,10 +364,11 @@ export class MetabaseServer {
                 },
                 row_limit: {
                   type: 'number',
-                  description: 'Maximum number of rows to return (default: 500, max: 2000)',
-                  default: 500,
+                  description:
+                    'Maximum number of rows to return (default: 100, max: 500). For larger datasets, use the export tool.',
+                  default: 100,
                   minimum: 1,
-                  maximum: 2000,
+                  maximum: 500,
                 },
               },
               required: [],

--- a/src/utils/errorFactory.ts
+++ b/src/utils/errorFactory.ts
@@ -181,7 +181,8 @@ export function createErrorFromHttpResponse(
       ) {
         return DatabaseErrorFactory.queryExecutionError(errorMessage);
       }
-      return new Error(`Server error: ${errorMessage}`);
+      // Pass through the error message directly - it's already descriptive
+      return new Error(errorMessage);
 
     case 502:
     case 503:

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -164,7 +164,7 @@ export function validateRowLimit(
   requestId: string,
   logWarn: (message: string, data?: unknown, error?: Error) => void,
   min: number = 1,
-  max: number = 2000
+  max: number = 500
 ): asserts value is number {
   if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
     const errorMessage = `Invalid ${fieldName} parameter: ${value}. Must be between ${min} and ${max}.`;

--- a/tests/handlers/execute.test.ts
+++ b/tests/handlers/execute.test.ts
@@ -168,7 +168,7 @@ describe('handleExecute (execute command)', () => {
       ).rejects.toThrow(McpError);
 
       expect(mockLogger.logWarn).toHaveBeenCalledWith(
-        'Invalid row_limit parameter: 0. Must be between 1 and 2000.',
+        'Invalid row_limit parameter: 0. Must be between 1 and 500.',
         { requestId: 'test-request-id' }
       );
     });
@@ -177,7 +177,7 @@ describe('handleExecute (execute command)', () => {
       const request = createMockRequest('execute', {
         database_id: 1,
         query: 'SELECT 1',
-        row_limit: 3000
+        row_limit: 600
       });
       const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
 
@@ -186,7 +186,7 @@ describe('handleExecute (execute command)', () => {
       ).rejects.toThrow(McpError);
 
       expect(mockLogger.logWarn).toHaveBeenCalledWith(
-        'Invalid row_limit parameter: 3000. Must be between 1 and 2000.',
+        'Invalid row_limit parameter: 600. Must be between 1 and 500.',
         { requestId: 'test-request-id' }
       );
     });
@@ -355,7 +355,7 @@ describe('handleExecute (execute command)', () => {
         body: JSON.stringify({
           type: 'native',
           native: {
-            query: 'SELECT * FROM users LIMIT 500',
+            query: 'SELECT * FROM users LIMIT 100',
             template_tags: {},
           },
           parameters: [],
@@ -467,7 +467,7 @@ describe('handleExecute (execute command)', () => {
         body: JSON.stringify({
           type: 'native',
           native: {
-            query: 'SELECT * FROM users WHERE id = {{user_id}} LIMIT 500',
+            query: 'SELECT * FROM users WHERE id = {{user_id}} LIMIT 100',
             template_tags: {},
           },
           parameters: nativeParameters,
@@ -776,7 +776,7 @@ describe('handleExecute (execute command)', () => {
       await handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
       expect(mockLogger.logDebug).toHaveBeenCalledWith(
-        'Executing card ID: 123 with row limit: 500'
+        'Executing card ID: 123 with row limit: 100'
       );
       expect(mockLogger.logInfo).toHaveBeenCalledWith(
         'Successfully executed card: 123, returned 2 rows (original: 2)'
@@ -801,7 +801,7 @@ describe('handleExecute (execute command)', () => {
         body: JSON.stringify({
           type: 'native',
           native: {
-            query: 'SELECT * FROM users LIMIT 500',
+            query: 'SELECT * FROM users LIMIT 100',
             template_tags: {},
           },
           parameters: [],
@@ -826,7 +826,7 @@ describe('handleExecute (execute command)', () => {
         body: JSON.stringify({
           type: 'native',
           native: {
-            query: 'SELECT * FROM users LIMIT 500;',
+            query: 'SELECT * FROM users LIMIT 100;',
             template_tags: {},
           },
           parameters: [],
@@ -849,7 +849,7 @@ describe('handleExecute (execute command)', () => {
       await handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
       expect(mockLogger.logDebug).toHaveBeenCalledWith(
-        'Executing SQL query against database ID: 1 with row limit: 500'
+        'Executing SQL query against database ID: 1 with row limit: 100'
       );
     });
 
@@ -887,7 +887,7 @@ describe('handleExecute (execute command)', () => {
         body: JSON.stringify({
           type: 'native',
           native: {
-            query: 'SELECT * FROM users LIMIT 500',
+            query: 'SELECT * FROM users LIMIT 100',
             template_tags: {},
           },
           parameters: [],
@@ -912,7 +912,7 @@ describe('handleExecute (execute command)', () => {
         body: JSON.stringify({
           type: 'native',
           native: {
-            query: 'SELECT * FROM users LIMIT 500',
+            query: 'SELECT * FROM users LIMIT 100',
             template_tags: {},
           },
           parameters: [],

--- a/tests/handlers/export.test.ts
+++ b/tests/handlers/export.test.ts
@@ -240,10 +240,8 @@ describe('handleExport (export command)', () => {
       
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
-      expect(responseData.format).toBe('csv');
       expect(responseData.row_count).toBe(2);
-      expect(responseData.database_id).toBe(1);
-      expect(responseData.query).toBe('SELECT * FROM users');
+      expect(responseData.file_path).toContain('.csv');
     });
 
     it('should export SQL query in JSON format successfully', async () => {
@@ -277,8 +275,8 @@ describe('handleExport (export command)', () => {
       expect(result.content).toHaveLength(1);
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
-      expect(responseData.format).toBe('json');
       expect(responseData.row_count).toBe(2);
+      expect(responseData.file_path).toContain('.json');
     });
 
     it('should export SQL query in XLSX format successfully', async () => {
@@ -309,7 +307,7 @@ describe('handleExport (export command)', () => {
       expect(result.content).toHaveLength(1);
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
-      expect(responseData.format).toBe('xlsx');
+      expect(responseData.file_path).toContain('.xlsx');
       expect(responseData.row_count).toBe(3); // 3 data rows in mock
       expect(responseData.file_size_bytes).toBeGreaterThan(1000); // XLSX files are typically larger
       expect(responseData.preview_data).toHaveLength(3); // Should have preview of all 3 rows
@@ -318,7 +316,6 @@ describe('handleExport (export command)', () => {
         'Age': 30,
         'City': 'New York'
       });
-      expect(responseData.preview_note).toContain('First 3 rows shown (3 total rows exported)');
     });
 
     it('should handle empty query results', async () => {
@@ -349,7 +346,7 @@ describe('handleExport (export command)', () => {
       expect(result.content).toHaveLength(1);
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(false);
-      expect(responseData.message).toBe('Query executed successfully but returned no data to export');
+      expect(responseData.error).toBe('Query returned no data to export');
     });
 
     it('should handle SQL export with custom filename', async () => {
@@ -378,7 +375,8 @@ describe('handleExport (export command)', () => {
       );
 
       const responseData = JSON.parse(result.content[0].text);
-      expect(responseData.filename).toBe('my_custom_export.csv');
+      expect(responseData.success).toBe(true);
+      expect(responseData.file_path).toContain('my_custom_export.csv');
     });
   });
 
@@ -464,7 +462,6 @@ describe('handleExport (export command)', () => {
       expect(result.content).toHaveLength(1);
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
-      expect(responseData.card_id).toBe(1);
     });
   });
 
@@ -503,9 +500,7 @@ describe('handleExport (export command)', () => {
       expect(result.content).toHaveLength(1);
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
-      expect(responseData.card_id).toBe(123);
-      expect(responseData.card_name).toBe('User Report');
-      expect(responseData.format).toBe('csv');
+      expect(responseData.file_path).toContain('.csv');
     });
 
     it('should export card with parameters', async () => {
@@ -549,7 +544,6 @@ describe('handleExport (export command)', () => {
 
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
-      expect(responseData.card_id).toBe(123);
 
       // Verify the request was made with parameters in the correct format
       expect(mockFetch).toHaveBeenCalledWith(
@@ -678,7 +672,7 @@ describe('handleExport (export command)', () => {
       );
 
       const responseData = JSON.parse(result.content[0].text);
-      expect(responseData.format).toBe('csv');
+      expect(responseData.file_path).toContain('.csv');
     });
 
     it('should handle uppercase format parameters', async () => {
@@ -706,7 +700,7 @@ describe('handleExport (export command)', () => {
       );
 
       const responseData = JSON.parse(result.content[0].text);
-      expect(responseData.format).toBe('csv');
+      expect(responseData.file_path).toContain('.csv');
     });
 
     it('should handle mixed case format parameters', async () => {
@@ -734,7 +728,7 @@ describe('handleExport (export command)', () => {
       );
 
       const responseData = JSON.parse(result.content[0].text);
-      expect(responseData.format).toBe('json');
+      expect(responseData.file_path).toContain('.json');
     });
 
     it('should handle XLSX format case-insensitively', async () => {
@@ -745,7 +739,7 @@ describe('handleExport (export command)', () => {
       });
       const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
 
-      const mockArrayBuffer = new ArrayBuffer(1024);
+      const mockArrayBuffer = createMockXlsxWithData();
       mockFetch.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: () => Promise.resolve(mockArrayBuffer),
@@ -762,7 +756,7 @@ describe('handleExport (export command)', () => {
       );
 
       const responseData = JSON.parse(result.content[0].text);
-      expect(responseData.format).toBe('xlsx');
+      expect(responseData.file_path).toContain('.xlsx');
     });
   });
 });

--- a/tests/handlers/retrieve.test.ts
+++ b/tests/handlers/retrieve.test.ts
@@ -251,9 +251,8 @@ describe('handleRetrieve', () => {
       const result = await handleRetrieve(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
       expect(mockApiClient.getCard).toHaveBeenCalledTimes(2);
-      expect(result.content[0].text).toContain('successful_retrievals');
-      expect(result.content[0].text).toContain('failed_retrievals');
-      expect(result.content[0].text).toContain('1/2 cards successfully');
+      expect(result.content[0].text).toContain('"successful_retrievals": 1');
+      expect(result.content[0].text).toContain('"failed_retrievals": 1');
     });
 
     it('should include values_source_type and values_source_config in card parameters', async () => {
@@ -738,7 +737,8 @@ describe('handleRetrieve', () => {
       const request = createMockRequest('retrieve', { model: 'card', ids: [1] });
       const result = await handleRetrieve(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('"primary_source": "cache"');
+      expect(result.content[0].text).toContain('"cache": 1');
+      expect(result.content[0].text).toContain('"api": 0');
     });
 
     it('should indicate API source in response', async () => {
@@ -748,7 +748,8 @@ describe('handleRetrieve', () => {
       const request = createMockRequest('retrieve', { model: 'card', ids: [1] });
       const result = await handleRetrieve(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('"primary_source": "api"');
+      expect(result.content[0].text).toContain('"cache": 0');
+      expect(result.content[0].text).toContain('"api": 1');
     });
   });
 


### PR DESCRIPTION
## Summary

- Optimize execute tool response by removing query from output and reducing default row limits (500 -> 100, max 2000 -> 500)
- Simplify list and retrieve response structures by removing performance metrics, timestamps, and redundant fields
- Streamline export responses to essential fields only (success, file_path, row_count, file_size_bytes, preview_data)
- Improve error handling to surface actual Metabase error messages instead of generic ones
- Separate card-specific and query-specific error handling to accommodate different Metabase API behaviors

## Test plan

- [x] All 276 tests pass
- [x] Manually tested execute_card with invalid parameters (Test 1: invalid param name, Test 2: invalid value)
- [x] Manually tested export_card with all formats (JSON, CSV, XLSX) for error handling
- [x] Verified error messages are clean and descriptive without redundant prefixes