### PR TITLE
fix: release workflow MCPB and npm publish issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install MCPB CLI
+        run: npm install -g @anthropic-ai/mcpb
+
       - name: Build MCPB package
         run: npm run mcpb:build
 
@@ -122,7 +125,17 @@ jobs:
         run: npm run build:fast
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          # Check if version already exists on npm
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null; then
+            echo "Version ${PACKAGE_VERSION} already exists on npm, skipping publish"
+          else
+            echo "Publishing ${PACKAGE_NAME}@${PACKAGE_VERSION} to npm"
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

Fixes release workflow issues discovered during v1.1.3 release:

- Add missing MCPB CLI installation step (lost during workflow consolidation)
- Skip npm publish if version already exists (enables safe workflow re-runs)

## Context

The v1.1.3 release partially failed:
- Docker and npm published successfully
- MCPB build failed due to missing `@anthropic-ai/mcpb` CLI
- GitHub Release was not created (depends on all jobs succeeding)

## Changes

1. **MCPB CLI**: Added `npm install -g @anthropic-ai/mcpb` step before building MCPB package

2. **npm publish**: Added version existence check to skip publish if already on npm (prevents failures on re-runs)