### PR TITLE
fix: exclude test files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "metabase-mcp": "./build/src/index.js"
   },
   "files": [
-    "build"
+    "build/src"
   ],
   "scripts": {
     "build": "npm run validate && tsc && npm test && node -e \"require('fs').chmodSync('build/src/index.js', '755')\"",


### PR DESCRIPTION
Changed files field from "build" to "build/src" to prevent
compiled test files (build/tests/) from being published to npm.