### PR TITLE
feat: compact JSON responses with debug pretty-printing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,11 @@ METABASE_USER_EMAIL=email@example.com
 METABASE_PASSWORD=password
 
 # Optional
-LOG_LEVEL=info                         # debug, info, warn, error, fatal
+LOG_LEVEL=info                         # debug, info, warn, error, fatal (debug enables pretty JSON)
 CACHE_TTL_MS=600000                    # 10 min default
 REQUEST_TIMEOUT_MS=600000              # 10 min default
 EXPORT_DIRECTORY=~/Downloads/Metabase
 METABASE_READ_ONLY_MODE=true           # Restrict to SELECT queries
-JSON_BEAUTIFY=false                    # Beautify JSON responses (compact by default)
 ```
 
 ## Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ CACHE_TTL_MS=600000                    # 10 min default
 REQUEST_TIMEOUT_MS=600000              # 10 min default
 EXPORT_DIRECTORY=~/Downloads/Metabase
 METABASE_READ_ONLY_MODE=true           # Restrict to SELECT queries
+JSON_BEAUTIFY=false                    # Beautify JSON responses (compact by default)
 ```
 
 ## Rules

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Add the following to your MCP client configuration:
         "METABASE_READ_ONLY_MODE": "true",             // Restrict to SELECT queries
         "LOG_LEVEL": "info",                           // debug, info, warn, error, fatal
         "CACHE_TTL_MS": "600000",                      // 10 minutes
-        "REQUEST_TIMEOUT_MS": "600000"                 // 10 minutes
+        "REQUEST_TIMEOUT_MS": "600000",                // 10 minutes
+        "JSON_BEAUTIFY": "false"                       // Beautify JSON responses (compact by default)
       }
     }
   }
@@ -85,7 +86,7 @@ Or build locally: `docker build -t metabase-mcp .` and use `metabase-mcp` as the
 
 **Required flags:** `-i` (interactive, for MCP stdio), `--rm` (cleanup), `--init` (signal handling)
 
-**Environment variables:** Pass via `-e` flags. See [Manual Configuration](#option-2-manual-configuration) for all options. Docker defaults: `LOG_LEVEL=info`, `METABASE_READ_ONLY_MODE=true`, `EXPORT_DIRECTORY=/home/node/exports`.
+**Environment variables:** Pass via `-e` flags. See [Manual Configuration](#option-2-manual-configuration) for all options. Docker defaults: `LOG_LEVEL=info`, `METABASE_READ_ONLY_MODE=true`, `EXPORT_DIRECTORY=/home/node/exports`, `JSON_BEAUTIFY=false`.
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ Add the following to your MCP client configuration:
         // Optional (defaults shown)
         "EXPORT_DIRECTORY": "~/Downloads/Metabase",    // Export location
         "METABASE_READ_ONLY_MODE": "true",             // Restrict to SELECT queries
-        "LOG_LEVEL": "info",                           // debug, info, warn, error, fatal
+        "LOG_LEVEL": "info",                           // debug, info, warn, error, fatal (debug enables pretty JSON)
         "CACHE_TTL_MS": "600000",                      // 10 minutes
-        "REQUEST_TIMEOUT_MS": "600000",                // 10 minutes
-        "JSON_BEAUTIFY": "false"                       // Beautify JSON responses (compact by default)
+        "REQUEST_TIMEOUT_MS": "600000"                 // 10 minutes
       }
     }
   }
@@ -86,7 +85,7 @@ Or build locally: `docker build -t metabase-mcp .` and use `metabase-mcp` as the
 
 **Required flags:** `-i` (interactive, for MCP stdio), `--rm` (cleanup), `--init` (signal handling)
 
-**Environment variables:** Pass via `-e` flags. See [Manual Configuration](#option-2-manual-configuration) for all options. Docker defaults: `LOG_LEVEL=info`, `METABASE_READ_ONLY_MODE=true`, `EXPORT_DIRECTORY=/home/node/exports`, `JSON_BEAUTIFY=false`.
+**Environment variables:** Pass via `-e` flags. See [Manual Configuration](#option-2-manual-configuration) for all options. Docker defaults: `LOG_LEVEL=info`, `METABASE_READ_ONLY_MODE=true`, `EXPORT_DIRECTORY=/home/node/exports`.
 
 ## Available Tools
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "metabase-mcp": "./build/src/index.js"
   },
   "files": [
-    "build"
+    "build/src"
   ],
   "scripts": {
     "build": "npm run validate && tsc && npm test && node -e \"require('fs').chmodSync('build/src/index.js', '755')\"",

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,10 @@ const envSchema = z
       .string()
       .default('true')
       .transform(val => val.toLowerCase() === 'true'),
+    JSON_BEAUTIFY: z
+      .string()
+      .default('false')
+      .transform(val => val.toLowerCase() === 'true'),
   })
   .refine(data => data.METABASE_API_KEY || (data.METABASE_USER_EMAIL && data.METABASE_PASSWORD), {
     message:
@@ -85,6 +89,7 @@ function createTestConfig() {
     REQUEST_TIMEOUT_MS: 600000,
     EXPORT_DIRECTORY: join(homedir(), 'Downloads', 'Metabase'),
     METABASE_READ_ONLY_MODE: true,
+    JSON_BEAUTIFY: false,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,10 +52,6 @@ const envSchema = z
       .string()
       .default('true')
       .transform(val => val.toLowerCase() === 'true'),
-    JSON_BEAUTIFY: z
-      .string()
-      .default('false')
-      .transform(val => val.toLowerCase() === 'true'),
   })
   .refine(data => data.METABASE_API_KEY || (data.METABASE_USER_EMAIL && data.METABASE_PASSWORD), {
     message:
@@ -89,7 +85,6 @@ function createTestConfig() {
     REQUEST_TIMEOUT_MS: 600000,
     EXPORT_DIRECTORY: join(homedir(), 'Downloads', 'Metabase'),
     METABASE_READ_ONLY_MODE: true,
-    JSON_BEAUTIFY: false,
   };
 }
 

--- a/src/handlers/clearCache.ts
+++ b/src/handlers/clearCache.ts
@@ -1,6 +1,6 @@
 import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { MetabaseApiClient } from '../api.js';
-import { handleApiError, validateEnumValue } from '../utils/index.js';
+import { handleApiError, validateEnumValue, formatJson } from '../utils/index.js';
 
 export function handleClearCache(
   request: CallToolRequest,
@@ -142,26 +142,22 @@ export function handleClearCache(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(
-            {
-              message,
-              cache_type: cacheType,
-              cache_status: cacheStatus,
-              next_fetch_will_be: 'fresh from API',
-              cache_info: {
-                cache_explanation:
-                  'Unified cache system with separate individual item and list caches for optimal performance',
-                cache_types: {
-                  individual:
-                    'Cache for specific items accessed by ID (cards, dashboards, tables, databases, collections, fields)',
-                  lists:
-                    'Cache for bulk list operations (cards-list, dashboards-list, tables-list, databases-list, collections-list)',
-                },
+          text: formatJson({
+            message,
+            cache_type: cacheType,
+            cache_status: cacheStatus,
+            next_fetch_will_be: 'fresh from API',
+            cache_info: {
+              cache_explanation:
+                'Unified cache system with separate individual item and list caches for optimal performance',
+              cache_types: {
+                individual:
+                  'Cache for specific items accessed by ID (cards, dashboards, tables, databases, collections, fields)',
+                lists:
+                  'Cache for bulk list operations (cards-list, dashboards-list, tables-list, databases-list, collections-list)',
               },
             },
-            null,
-            2
-          ),
+          }),
         },
       ],
     };

--- a/src/handlers/execute/executeCard.ts
+++ b/src/handlers/execute/executeCard.ts
@@ -3,6 +3,7 @@ import {
   handleApiError,
   validatePositiveInteger,
   validateMetabaseResponse,
+  formatJson,
 } from '../../utils/index.js';
 import { CardExecutionParams, ExecutionResponse } from './types.js';
 
@@ -96,18 +97,14 @@ export async function executeCard(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(
-            {
-              success: true,
-              card_id: cardId,
-              row_count: finalRowCount,
-              original_row_count: originalRowCount,
-              applied_limit: rowLimit,
-              data: limitedData,
-            },
-            null,
-            2
-          ),
+          text: formatJson({
+            success: true,
+            card_id: cardId,
+            row_count: finalRowCount,
+            original_row_count: originalRowCount,
+            applied_limit: rowLimit,
+            data: limitedData,
+          }),
         },
       ],
     };

--- a/src/handlers/execute/executeQuery.ts
+++ b/src/handlers/execute/executeQuery.ts
@@ -3,6 +3,7 @@ import {
   handleApiError,
   validatePositiveInteger,
   validateMetabaseResponse,
+  formatJson,
 } from '../../utils/index.js';
 import { SqlExecutionParams, ExecutionResponse } from './types.js';
 import { optimizeExecuteData } from './optimizers.js';
@@ -152,17 +153,13 @@ export async function executeSqlQuery(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(
-            {
-              success: true,
-              database_id: databaseId,
-              row_count: rowCount,
-              applied_limit: finalLimit,
-              data: optimizedData,
-            },
-            null,
-            2
-          ),
+          text: formatJson({
+            success: true,
+            database_id: databaseId,
+            row_count: rowCount,
+            applied_limit: finalLimit,
+            data: optimizedData,
+          }),
         },
       ],
     };

--- a/src/handlers/export/exportCard.ts
+++ b/src/handlers/export/exportCard.ts
@@ -4,6 +4,7 @@ import {
   sanitizeFilename,
   analyzeXlsxContent,
   validateMetabaseResponse,
+  formatJson,
 } from '../../utils/index.js';
 import { config, authMethod, AuthMethod } from '../../config.js';
 import * as XLSX from 'xlsx';
@@ -237,14 +238,10 @@ export async function exportCard(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(
-              {
-                success: false,
-                error: 'Card returned no data to export',
-              },
-              null,
-              2
-            ),
+            text: formatJson({
+              success: false,
+              error: 'Card returned no data to export',
+            }),
           },
         ],
       };
@@ -305,7 +302,7 @@ export async function exportCard(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(errorResponse, null, 2),
+            text: formatJson(errorResponse),
           },
         ],
         isError: true,
@@ -328,7 +325,7 @@ export async function exportCard(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(successResponse, null, 2),
+          text: formatJson(successResponse),
         },
       ],
     };

--- a/src/handlers/export/exportQuery.ts
+++ b/src/handlers/export/exportQuery.ts
@@ -4,6 +4,7 @@ import {
   sanitizeFilename,
   analyzeXlsxContent,
   validateMetabaseResponse,
+  formatJson,
 } from '../../utils/index.js';
 import { config, authMethod, AuthMethod } from '../../config.js';
 import * as XLSX from 'xlsx';
@@ -242,14 +243,10 @@ export async function exportSqlQuery(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(
-              {
-                success: false,
-                error: 'Query returned no data to export',
-              },
-              null,
-              2
-            ),
+            text: formatJson({
+              success: false,
+              error: 'Query returned no data to export',
+            }),
           },
         ],
       };
@@ -309,7 +306,7 @@ export async function exportSqlQuery(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(errorResponse, null, 2),
+            text: formatJson(errorResponse),
           },
         ],
         isError: true,
@@ -332,7 +329,7 @@ export async function exportSqlQuery(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(successResponse, null, 2),
+          text: formatJson(successResponse),
         },
       ],
     };

--- a/src/handlers/list/index.ts
+++ b/src/handlers/list/index.ts
@@ -6,6 +6,7 @@ import {
   validateEnumValue,
   parseAndValidatePositiveInteger,
   parseAndValidateNonNegativeInteger,
+  formatJson,
 } from '../../utils/index.js';
 import { ValidationErrorFactory } from '../../utils/errorFactory.js';
 import {
@@ -197,7 +198,7 @@ export async function handleList(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(response, null, 2),
+          text: formatJson(response),
         },
       ],
     };

--- a/src/handlers/resources/resourceHandlers.ts
+++ b/src/handlers/resources/resourceHandlers.ts
@@ -1,4 +1,4 @@
-import { generateRequestId } from '../../utils/index.js';
+import { generateRequestId, formatJson } from '../../utils/index.js';
 import { ErrorCode, McpError, isMcpError } from '../../types/core.js';
 import { MetabaseApiClient } from '../../api.js';
 import {
@@ -336,7 +336,7 @@ async function handleDashboardResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(optimizedDashboard, null, 2),
+      text: formatJson(optimizedDashboard),
     },
   ];
 
@@ -368,7 +368,7 @@ async function handleCardResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(optimizedCard, null, 2),
+      text: formatJson(optimizedCard),
     },
   ];
 
@@ -400,7 +400,7 @@ async function handleDatabaseResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(optimizedDatabase, null, 2),
+      text: formatJson(optimizedDatabase),
     },
   ];
 
@@ -432,7 +432,7 @@ async function handleTableResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(optimizedTable, null, 2),
+      text: formatJson(optimizedTable),
     },
   ];
 
@@ -493,7 +493,7 @@ async function handleFieldResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(optimizedField, null, 2),
+      text: formatJson(optimizedField),
     },
   ];
 
@@ -534,7 +534,7 @@ async function handleMetricResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(optimizedMetric, null, 2),
+      text: formatJson(optimizedMetric),
     },
   ];
 
@@ -618,7 +618,7 @@ async function handleCollectionResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(collectionWithItems, null, 2),
+      text: formatJson(collectionWithItems),
     },
   ];
 
@@ -687,7 +687,7 @@ async function handleRecentItemsResource(
     {
       uri,
       mimeType: 'application/json',
-      text: JSON.stringify(recentItems, null, 2),
+      text: formatJson(recentItems),
     },
   ];
 

--- a/src/handlers/retrieve/index.ts
+++ b/src/handlers/retrieve/index.ts
@@ -9,6 +9,7 @@ import {
   validateEnumValue,
   parseAndValidatePositiveInteger,
   parseAndValidateNonNegativeInteger,
+  formatJson,
 } from '../../utils/index.js';
 import {
   MAX_IDS_PER_REQUEST,
@@ -408,7 +409,7 @@ export async function handleRetrieve(
     logInfo(logMessage);
 
     // Monitor response size for token usage optimization feedback
-    const responseText = JSON.stringify(response, null, 2);
+    const responseText = formatJson(response);
     const responseSizeChars = responseText.length;
     const estimatedTokens = Math.ceil(responseSizeChars / 4); // Rough estimation: ~4 chars per token
 

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -2,7 +2,12 @@ import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { MetabaseApiClient } from '../api.js';
 import { ErrorCode, McpError } from '../types/core.js';
 import { ValidationErrorFactory } from '../utils/errorFactory.js';
-import { handleApiError, validatePositiveInteger, validateEnumValue } from '../utils/index.js';
+import {
+  handleApiError,
+  validatePositiveInteger,
+  validateEnumValue,
+  formatJson,
+} from '../utils/index.js';
 
 export async function handleSearch(
   request: CallToolRequest,
@@ -333,24 +338,20 @@ export async function handleSearch(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(
-            {
-              search_metrics: {
-                method: searchMethod,
-                total_results: totalResults,
-                search_time_ms: searchTime,
-                parameters_used: usedParameters,
-              },
-              recommended_actions: recommendedActions,
-              results_by_model: Object.keys(resultsByModel).map(model => ({
-                model,
-                count: resultsByModel[model].length,
-              })),
-              results: enhancedResults,
+          text: formatJson({
+            search_metrics: {
+              method: searchMethod,
+              total_results: totalResults,
+              search_time_ms: searchTime,
+              parameters_used: usedParameters,
             },
-            null,
-            2
-          ),
+            recommended_actions: recommendedActions,
+            results_by_model: Object.keys(resultsByModel).map(model => ({
+              model,
+              count: resultsByModel[model].length,
+            })),
+            results: enhancedResults,
+          }),
         },
       ],
     };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,3 +16,6 @@ export * from './fileUtils.js';
 
 // Request utilities
 export * from './requestUtils.js';
+
+// JSON formatting
+export * from './jsonFormatting.js';

--- a/src/utils/jsonFormatting.ts
+++ b/src/utils/jsonFormatting.ts
@@ -6,11 +6,11 @@ import { config } from '../config.js';
 
 /**
  * Formats a value as JSON string for MCP responses.
- * Uses compact format by default, beautified when JSON_BEAUTIFY=true.
+ * Uses compact format by default, pretty-printed when LOG_LEVEL=debug.
  *
  * @param data - The data to format as JSON
- * @returns JSON string (compact or beautified based on config)
+ * @returns JSON string (compact or pretty-printed based on LOG_LEVEL)
  */
 export function formatJson(data: unknown): string {
-  return config.JSON_BEAUTIFY ? JSON.stringify(data, null, 2) : JSON.stringify(data);
+  return config.LOG_LEVEL === 'debug' ? JSON.stringify(data, null, 2) : JSON.stringify(data);
 }

--- a/src/utils/jsonFormatting.ts
+++ b/src/utils/jsonFormatting.ts
@@ -1,0 +1,16 @@
+/**
+ * JSON formatting utility for MCP responses
+ */
+
+import { config } from '../config.js';
+
+/**
+ * Formats a value as JSON string for MCP responses.
+ * Uses compact format by default, beautified when JSON_BEAUTIFY=true.
+ *
+ * @param data - The data to format as JSON
+ * @returns JSON string (compact or beautified based on config)
+ */
+export function formatJson(data: unknown): string {
+  return config.JSON_BEAUTIFY ? JSON.stringify(data, null, 2) : JSON.stringify(data);
+}

--- a/tests/handlers/list.test.ts
+++ b/tests/handlers/list.test.ts
@@ -93,7 +93,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'cards' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('total_items": 0');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.total_items).toBe(0);
     });
 
     it('should handle API errors for cards', async () => {
@@ -129,7 +130,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'dashboards' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('total_items": 0');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.total_items).toBe(0);
     });
   });
 
@@ -153,7 +155,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'tables' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('total_items": 0');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.total_items).toBe(0);
     });
   });
 
@@ -177,7 +180,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'databases' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('total_items": 0');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.total_items).toBe(0);
     });
   });
 
@@ -201,7 +205,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'collections' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('total_items": 0');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.total_items).toBe(0);
     });
   });
 
@@ -235,7 +240,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'cards' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('"source": "cache"');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.source).toBe('cache');
     });
 
     it('should indicate API source in response', async () => {
@@ -245,7 +251,8 @@ describe('handleList', () => {
       const request = createMockRequest('list', { model: 'cards' });
       const result = await handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('"source": "api"');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.source).toBe('api');
     });
   });
 

--- a/tests/handlers/retrieve.test.ts
+++ b/tests/handlers/retrieve.test.ts
@@ -251,8 +251,9 @@ describe('handleRetrieve', () => {
       const result = await handleRetrieve(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
       expect(mockApiClient.getCard).toHaveBeenCalledTimes(2);
-      expect(result.content[0].text).toContain('"successful_retrievals": 1');
-      expect(result.content[0].text).toContain('"failed_retrievals": 1');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.successful_retrievals).toBe(1);
+      expect(responseData.failed_retrievals).toBe(1);
     });
 
     it('should include values_source_type and values_source_config in card parameters', async () => {
@@ -737,8 +738,9 @@ describe('handleRetrieve', () => {
       const request = createMockRequest('retrieve', { model: 'card', ids: [1] });
       const result = await handleRetrieve(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('"cache": 1');
-      expect(result.content[0].text).toContain('"api": 0');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.source.cache).toBe(1);
+      expect(responseData.source.api).toBe(0);
     });
 
     it('should indicate API source in response', async () => {
@@ -748,8 +750,9 @@ describe('handleRetrieve', () => {
       const request = createMockRequest('retrieve', { model: 'card', ids: [1] });
       const result = await handleRetrieve(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('"cache": 0');
-      expect(result.content[0].text).toContain('"api": 1');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.source.cache).toBe(0);
+      expect(responseData.source.api).toBe(1);
     });
   });
 

--- a/tests/handlers/search.test.ts
+++ b/tests/handlers/search.test.ts
@@ -203,8 +203,9 @@ describe('handleSearch', () => {
       const request = createMockRequest('search', { query: 'nonexistent' });
       const result = await handleSearch(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError);
 
-      expect(result.content[0].text).toContain('total_results');
-      expect(result.content[0].text).toContain('"results": []');
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.search_metrics.total_results).toBeDefined();
+      expect(responseData.results).toEqual([]);
     });
 
     it('should handle API errors', async () => {


### PR DESCRIPTION
## Summary

- Make JSON responses compact by default to reduce token usage
- Automatically enable pretty-printed JSON when `LOG_LEVEL=debug`
- Simplifies configuration by tying formatting to debug mode rather than a separate env var

## Changes

- Add `formatJson()` utility that checks `LOG_LEVEL` for formatting
- Update all handlers to use centralized JSON formatting
- Fix tests to use JSON parsing instead of string matching (more robust)
- Update documentation in CLAUDE.md and README.md

## Behavior

| Mode | JSON Format |
|------|-------------|
| Default (`LOG_LEVEL=info`) | Compact |
| Debug (`LOG_LEVEL=debug`) | Pretty-printed |

## Test plan

- [x] All 276 tests pass
- [x] Manually verified compact output with default settings
- [x] Manually verified pretty output with `LOG_LEVEL=debug`
- [x] Export functionality unaffected (only MCP responses change)