### PR TITLE
chore: bump version to v1.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:lts-alpine
 
 LABEL maintainer="Jericho Sequitin <https://github.com/jerichosequitin>"
 LABEL description="High-performance MCP server for Metabase with response optimization and robust error handling"
-LABEL version="1.1.3"
+LABEL version="1.1.4"
 
 # Set working directory
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/jerichosequitin/metabase-mcp)
 
-**Version**: 1.1.3
+**Version**: 1.1.4
 
 **Author**: Jericho Sequitin (@jerichosequitin)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "metabase-mcp",
   "display_name": "Metabase",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A high-performance MCP server for Metabase analytics data access with response optimization and robust error handling.",
   "long_description": "This MCP server provides AI assistants with optimized access to Metabase analytics data. Features up to 90% token reduction through response optimization, comprehensive error handling with structured responses, and tools for searching, listing, retrieving, and exporting data from Metabase instances. Includes concurrent processing, pagination support, and export capabilities for large datasets. Supports both API key and email/password authentication methods.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@jericho/metabase-mcp",
-  "version": "1.1.2",
+  "name": "@jerichosequitin/metabase-mcp",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@jericho/metabase-mcp",
-      "version": "1.1.2",
+      "name": "@jerichosequitin/metabase-mcp",
+      "version": "1.1.4",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@types/xlsx": "^0.0.35",
@@ -4365,6 +4366,7 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerichosequitin/metabase-mcp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A high-performance MCP server for Metabase analytics integration with response optimization and robust error handling",
   "type": "module",
   "author": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-const VERSION = '1.1.3';
+const VERSION = '1.1.4';
 import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,


### PR DESCRIPTION
## Summary

Version bump to v1.1.4

## Changes in this release

- Compact JSON responses by default (reduces token usage)
- Pretty-printed JSON automatically enabled when `LOG_LEVEL=debug`
- Exclude test files from npm distribution

## Test plan

- [x] All 276 tests pass
- [x] Version synced across package.json, README.md, manifest.json, Dockerfile, src/server.ts