### PR TITLE
docs: add project badges and export limitation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# Metabase MCP Server
+# Metabase MCP
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/jerichosequitin/metabase-mcp)
+[![npm version](https://img.shields.io/npm/v/@jerichosequitin/metabase-mcp)](https://www.npmjs.com/package/@jerichosequitin/metabase-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18.0.0-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.3-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![GitHub stars](https://img.shields.io/github/stars/jerichosequitin/metabase-mcp)](https://github.com/jerichosequitin/metabase-mcp/stargazers)
+
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/jerichosequitin)
+
+<a href="https://glama.ai/mcp/servers/@jerichosequitin/Metabase">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jerichosequitin/Metabase/badge" />
+</a>
+
+&nbsp;
 
 **Version**: 1.1.4
 
@@ -116,6 +129,7 @@ Export large datasets up to 1M rows to the configured export directory.
 - **Formats**: CSV, JSON, XLSX
 - **SQL Mode**: Export custom query results
 - **Card Mode**: Export saved card results with optional filtering
+- **Note**: When using hosted remote deployments (e.g., Glama), exported files are saved inside the container and are inaccessible. Use `execute` for query results directly, or run locally via npx/Docker for full export functionality.
 
 ### `clear_cache`
 Clear internal cache with granular control.

--- a/README.md
+++ b/README.md
@@ -9,17 +9,11 @@
 
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/jerichosequitin)
 
+A high-performance Model Context Protocol server for AI integration with Metabase analytics platforms. Features response optimization, robust error handling, and comprehensive data access tools.
+
 <a href="https://glama.ai/mcp/servers/@jerichosequitin/Metabase">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@jerichosequitin/Metabase/badge" />
 </a>
-
-&nbsp;
-
-**Version**: 1.1.4
-
-**Author**: Jericho Sequitin (@jerichosequitin)
-
-A high-performance Model Context Protocol server for AI integration with Metabase analytics platforms. Features response optimization, robust error handling, and comprehensive data access tools.
 
 ## Key Features
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:coverage": "vitest run --coverage",
     "test:all": "./scripts/test-all.sh",
     "clean": "rm -rf build node_modules/.cache",
-    "version": "node scripts/sync-version.cjs && git add README.md manifest.json Dockerfile",
+    "version": "node scripts/sync-version.cjs && git add manifest.json Dockerfile src/server.ts",
     "mcpb:build": "npm run build && node scripts/build-mcpb.cjs",
     "mcpb:validate": "echo 'MCPB validation - checking manifest structure' && node -e \"const fs = require('fs'); const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8')); console.log('Manifest valid:', manifest.name, manifest.version);\""
   },

--- a/scripts/sync-version.cjs
+++ b/scripts/sync-version.cjs
@@ -11,11 +11,6 @@ const version = pkg.version;
 
 const files = [
   {
-    path: 'README.md',
-    pattern: /\*\*Version\*\*: [\d.]+/,
-    replacement: `**Version**: ${version}`,
-  },
-  {
     path: 'manifest.json',
     pattern: /"version": "[\d.]+"/,
     replacement: `"version": "${version}"`,


### PR DESCRIPTION
## Summary
- Rename README title to "Metabase MCP" for consistency with package/repo naming
- Add project badges: npm version, MIT license, Node.js, TypeScript, GitHub stars
- Add support badges: Buy Me A Coffee, Glama
- Document export tool limitation for hosted remote deployments

## Test plan
- [x] Verify badges render correctly on GitHub
- [x] Verify links point to correct destinations