### PR TITLE
feat: add execute_dashboard tool (API-first dashboard exploration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Execute SQL queries or run saved cards with configurable row limits (default: 10
 ### `execute_dashboard`
 Execute all executable cards in a dashboard using dashboard context and optional dashboard-level filters.
 - **Input**: `dashboard_id` or `dashboard_url`
-- **Filters**: `dashboard_filters` as slug-to-value map (`string`, `number`, or `boolean`)
+- **Filters**: `dashboard_filters` as slug-to-value map (`string`/`number`/`boolean`, or arrays of those values for multi-select dimensions)
 - **Execution**: Runs each dashcard with dashboard context and returns normalized per-card data
 - **Limits**: `row_limit` per card (default: 100, max: 500)
 - **Behavior**: Best-effort execution (returns per-card errors/skips without failing the full response)

--- a/README.md
+++ b/README.md
@@ -119,12 +119,15 @@ Execute SQL queries or run saved cards with configurable row limits (default: 10
 - **Security**: Respects Read-Only Mode (blocks INSERT, UPDATE, DELETE, DROP, etc.)
 
 ### `execute_dashboard`
-Execute all executable cards in a dashboard using dashboard context and optional dashboard-level filters.
+Discover dashboard filter mappings or execute all executable cards in a dashboard using dashboard context.
 - **Input**: `dashboard_id` or `dashboard_url`
+- **Mode**: `mode="discover"` (recommended first) or `mode="execute"` (default)
 - **Filters**: `dashboard_filters` as slug-to-value map (`string`/`number`/`boolean`, or arrays of those values for multi-select dimensions)
+- **Discover**: Returns `execution_readiness`, `filter_mapping_matrix`, and `suggested_filter_payload` without executing cards
 - **Execution**: Runs each dashcard with dashboard context and returns normalized per-card data
+- **Strictness**: `strict_filters` (default true in execute mode) fails fast when provided filters are unknown or unmapped
 - **Limits**: `row_limit` per card (default: 100, max: 500)
-- **Behavior**: Best-effort execution (returns per-card errors/skips without failing the full response)
+- **Behavior**: After filter validation passes, execution is best-effort (returns per-card errors/skips without failing the full response)
 
 ### `export`
 Export large datasets up to 1M rows to the configured export directory.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Discover dashboard filter mappings or execute all executable cards in a dashboar
 - **Input**: `dashboard_id` or `dashboard_url`
 - **Mode**: `mode="discover"` (recommended first) or `mode="execute"` (default)
 - **Filters**: `dashboard_filters` as slug-to-value map (`string`/`number`/`boolean`, or arrays of those values for multi-select dimensions)
+- **URL Query Support**: If `dashboard_filters` is omitted, query params from `dashboard_url` are used as filter inputs
 - **Discover**: Returns `execution_readiness`, `filter_mapping_matrix`, and `suggested_filter_payload` without executing cards
 - **Execution**: Runs each dashcard with dashboard context and returns normalized per-card data
 - **Strictness**: `strict_filters` (default true in execute mode) fails fast when provided filters are unknown or unmapped

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A high-performance Model Context Protocol server for AI integration with Metabas
 - **Response Optimization**: Up to 90% token reduction for efficient AI context usage
 - **Robust Error Handling**: Comprehensive error handling with structured, actionable responses
 - **Smart Caching**: Multi-layer caching with configurable TTL for improved performance
-- **Unified Commands**: `list`, `retrieve`, `search`, `execute`, and `export` tools
+- **Unified Commands**: `list`, `retrieve`, `search`, `execute`, `execute_dashboard`, and `export` tools
 - **Dual Authentication**: API key or email/password authentication
 - **Large Data Export**: Export up to 1M rows in CSV, JSON, and XLSX formats
 - **Read-Only Mode**: Enabled by default to restrict execute to SELECT queries only
@@ -117,6 +117,14 @@ Execute SQL queries or run saved cards with configurable row limits (default: 10
 - **SQL Mode**: Custom queries with `database_id` and `query`
 - **Card Mode**: Saved cards with `card_id` and optional `card_parameters` for filtering
 - **Security**: Respects Read-Only Mode (blocks INSERT, UPDATE, DELETE, DROP, etc.)
+
+### `execute_dashboard`
+Execute all executable cards in a dashboard using dashboard context and optional dashboard-level filters.
+- **Input**: `dashboard_id` or `dashboard_url`
+- **Filters**: `dashboard_filters` as slug-to-value map (`string`, `number`, or `boolean`)
+- **Execution**: Runs each dashcard with dashboard context and returns normalized per-card data
+- **Limits**: `row_limit` per card (default: 100, max: 500)
+- **Behavior**: Best-effort execution (returns per-card errors/skips without failing the full response)
 
 ### `export`
 Export large datasets up to 1M rows to the configured export directory.

--- a/docs/responses/README.md
+++ b/docs/responses/README.md
@@ -22,6 +22,8 @@ Reference these files when modifying optimization functions in `src/handlers/ret
 
 - Returns only executable dashcard outputs (non-executable items are summarized in `skipped[]`).
 - Uses per-card row limits to cap payload size (`applied_limit`, `row_count`, `original_row_count`).
+- Includes `filter_resolution` so callers can quickly see which provided filter slugs matched dashboard params.
+- Includes per-card filter metadata (`applied_filters`, `applied_parameter_count`) for easier debugging.
 - Collapses per-card failures into concise `errors[]` entries instead of returning full raw error payloads.
 
 This structure trades some low-level raw API fidelity for significantly more predictable token usage in multi-card dashboard explorations.

--- a/docs/responses/README.md
+++ b/docs/responses/README.md
@@ -10,7 +10,18 @@ Local reference for Metabase API response structures. Avoids needing to consult 
 - `database.json` - Database connections
 - `field.json` - Table fields/columns
 - `table.json` - Database tables
+- `execute_dashboard.json` - Consolidated dashboard execution output with per-card results
 
 ## Usage
 
 Reference these files when modifying optimization functions in `src/handlers/retrieve/` or `src/types/optimized.ts` to know what fields are available in raw Metabase responses.
+
+## Execute Dashboard Response Optimization Notes
+
+`execute_dashboard.json` reflects a normalized aggregate response designed for LLM consumption:
+
+- Returns only executable dashcard outputs (non-executable items are summarized in `skipped[]`).
+- Uses per-card row limits to cap payload size (`applied_limit`, `row_count`, `original_row_count`).
+- Collapses per-card failures into concise `errors[]` entries instead of returning full raw error payloads.
+
+This structure trades some low-level raw API fidelity for significantly more predictable token usage in multi-card dashboard explorations.

--- a/docs/responses/README.md
+++ b/docs/responses/README.md
@@ -11,6 +11,7 @@ Local reference for Metabase API response structures. Avoids needing to consult 
 - `field.json` - Table fields/columns
 - `table.json` - Database tables
 - `execute_dashboard.json` - Consolidated dashboard execution output with per-card results
+- `execute_dashboard_discover.json` - Preflight discovery output for filter mappings and readiness
 
 ## Usage
 
@@ -25,5 +26,11 @@ Reference these files when modifying optimization functions in `src/handlers/ret
 - Includes `filter_resolution` so callers can quickly see which provided filter slugs matched dashboard params.
 - Includes per-card filter metadata (`applied_filters`, `applied_parameter_count`) for easier debugging.
 - Collapses per-card failures into concise `errors[]` entries instead of returning full raw error payloads.
+
+`execute_dashboard_discover.json` provides a lightweight preflight contract for filter debugging:
+
+- Returns `execution_readiness.ready` and `blocking_issues` without executing cards.
+- Includes `filter_mapping_matrix` and per-dashcard mapping summaries to diagnose filter mismatches.
+- Returns `suggested_filter_payload` (for example, auto-wrapped dimension values as arrays) to reuse in execute mode.
 
 This structure trades some low-level raw API fidelity for significantly more predictable token usage in multi-card dashboard explorations.

--- a/docs/responses/execute_dashboard.json
+++ b/docs/responses/execute_dashboard.json
@@ -1,0 +1,59 @@
+{
+  "success": true,
+  "dashboard": {
+    "id": 123,
+    "name": "Revenue Dashboard",
+    "source": "api",
+    "total_dashcards": 4,
+    "executable_dashcards": 3,
+    "executed_cards": 2,
+    "failed_cards": 1,
+    "skipped_cards": 1
+  },
+  "applied_filters": {
+    "region": "EMEA",
+    "year": 2025
+  },
+  "warnings": ["Dashcard 12 has no parameter mapping for dashboard filter \"region\""],
+  "skipped": [
+    {
+      "dashcard_id": 19,
+      "card_id": null,
+      "reason": "non-executable dashcard (missing dashcard id or card id)"
+    }
+  ],
+  "errors": [
+    {
+      "dashcard_id": 13,
+      "card_id": 887,
+      "card_name": "Conversion Rate",
+      "error": "Dashboard card execution failed: Access denied."
+    }
+  ],
+  "cards": [
+    {
+      "dashcard_id": 11,
+      "card_id": 886,
+      "card_name": "Revenue by Region",
+      "status": "success",
+      "row_count": 100,
+      "original_row_count": 145,
+      "applied_limit": 100,
+      "data": {
+        "data": {
+          "rows": [["EMEA", 120034.5]],
+          "cols": [
+            {
+              "name": "region"
+            },
+            {
+              "name": "revenue"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "usage_guidance": "This response mirrors dashboard-style execution in API context. For very large cards or dashboards, reduce row_limit or run execute/export on specific card IDs.",
+  "retrieved_at": "2026-02-23T12:34:56.000Z"
+}

--- a/docs/responses/execute_dashboard.json
+++ b/docs/responses/execute_dashboard.json
@@ -1,5 +1,7 @@
 {
   "success": true,
+  "mode": "execute",
+  "strict_filters": true,
   "dashboard": {
     "id": 123,
     "name": "Revenue Dashboard",
@@ -16,17 +18,24 @@
   },
   "filter_resolution": {
     "provided_filter_slugs": ["region", "year"],
-    "matched_filter_slugs": ["region"],
-    "unmatched_filter_slugs": ["year"],
+    "matched_filter_slugs": ["region", "year"],
+    "unmatched_filter_slugs": [],
     "available_dashboard_filters": [
       {
+        "id": "param-region",
         "slug": "region",
         "name": "Region",
         "type": "category"
+      },
+      {
+        "id": "param-year",
+        "slug": "year",
+        "name": "Year",
+        "type": "number"
       }
     ]
   },
-  "warnings": ["Dashcard 12 has no parameter mapping for dashboard filter \"region\""],
+  "warnings": ["Filter \"region\" has 1 invalid parameter mapping target(s)"],
   "skipped": [
     {
       "dashcard_id": 19,

--- a/docs/responses/execute_dashboard.json
+++ b/docs/responses/execute_dashboard.json
@@ -14,6 +14,18 @@
     "region": "EMEA",
     "year": 2025
   },
+  "filter_resolution": {
+    "provided_filter_slugs": ["region", "year"],
+    "matched_filter_slugs": ["region"],
+    "unmatched_filter_slugs": ["year"],
+    "available_dashboard_filters": [
+      {
+        "slug": "region",
+        "name": "Region",
+        "type": "category"
+      }
+    ]
+  },
   "warnings": ["Dashcard 12 has no parameter mapping for dashboard filter \"region\""],
   "skipped": [
     {
@@ -39,6 +51,8 @@
       "row_count": 100,
       "original_row_count": 145,
       "applied_limit": 100,
+      "applied_filters": ["region"],
+      "applied_parameter_count": 1,
       "data": {
         "data": {
           "rows": [["EMEA", 120034.5]],

--- a/docs/responses/execute_dashboard_discover.json
+++ b/docs/responses/execute_dashboard_discover.json
@@ -1,0 +1,98 @@
+{
+  "success": true,
+  "mode": "discover",
+  "dashboard": {
+    "id": 123,
+    "name": "Revenue Dashboard",
+    "source": "api",
+    "total_dashcards": 4,
+    "executable_dashcards": 3,
+    "skipped_cards": 1
+  },
+  "applied_filters": {
+    "region": "EMEA",
+    "year": 2025
+  },
+  "filter_resolution": {
+    "provided_filter_slugs": ["region", "year"],
+    "matched_filter_slugs": ["region"],
+    "unmatched_filter_slugs": ["year"],
+    "available_dashboard_filters": [
+      {
+        "id": "param-region",
+        "slug": "region",
+        "name": "Region",
+        "type": "category"
+      }
+    ]
+  },
+  "filter_mapping_matrix": [
+    {
+      "filter_slug": "region",
+      "dashboard_parameter_id": "param-region",
+      "dashboard_parameter_name": "Region",
+      "dashboard_parameter_type": "category",
+      "mapped_dashcards": 2,
+      "mapped_cards": 2,
+      "mapped_targets": [
+        {
+          "target_type": "dimension",
+          "parameter_type": "category"
+        }
+      ],
+      "status": "mapped",
+      "issues": []
+    },
+    {
+      "filter_slug": "year",
+      "dashboard_parameter_id": null,
+      "dashboard_parameter_name": null,
+      "dashboard_parameter_type": null,
+      "mapped_dashcards": 0,
+      "mapped_cards": 0,
+      "mapped_targets": [],
+      "status": "blocked",
+      "issues": [
+        {
+          "code": "unknown_filter_slug",
+          "filter_slug": "year",
+          "message": "Provided filter slug \"year\" was not found in dashboard parameters"
+        }
+      ]
+    }
+  ],
+  "dashcards": [
+    {
+      "dashcard_id": 11,
+      "card_id": 886,
+      "card_name": "Revenue by Region",
+      "has_parameter_mappings": true,
+      "mapped_filter_slugs": ["region"],
+      "mapped_filter_count": 1
+    }
+  ],
+  "execution_readiness": {
+    "ready": false,
+    "blocking_issues": [
+      {
+        "code": "unknown_filter_slug",
+        "filter_slug": "year",
+        "message": "Provided filter slug \"year\" was not found in dashboard parameters"
+      }
+    ],
+    "warnings": [],
+    "suggested_filter_payload": {
+      "region": ["EMEA"],
+      "year": 2025
+    }
+  },
+  "skipped": [
+    {
+      "dashcard_id": 19,
+      "card_id": null,
+      "reason": "non-executable dashcard (missing dashcard id or card id)"
+    }
+  ],
+  "usage_guidance": "Use mode=\"execute\" with suggested_filter_payload to run cards after readiness is true.",
+  "retrieved_at": "2026-02-23T12:34:56.000Z"
+}

--- a/manifest.json
+++ b/manifest.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "execute_dashboard",
-      "description": "Execute all executable cards in a dashboard with optional dashboard-level filters and consolidated per-card results."
+      "description": "Discover dashboard filter mappings or execute all executable cards with optional dashboard-level filters and consolidated per-card results."
     },
     {
       "name": "export",

--- a/manifest.json
+++ b/manifest.json
@@ -19,9 +19,7 @@
     "entry_point": "build/src/index.js",
     "mcp_config": {
       "command": "node",
-      "args": [
-        "${__dirname}/build/src/index.js"
-      ],
+      "args": ["${__dirname}/build/src/index.js"],
       "env": {
         "METABASE_URL": "${user_config.metabase_url}",
         "METABASE_API_KEY": "${user_config.metabase_api_key}",
@@ -48,6 +46,10 @@
     {
       "name": "execute",
       "description": "Execute SQL queries or run saved cards against Metabase databases. Warning: Can execute destructive SQL operations."
+    },
+    {
+      "name": "execute_dashboard",
+      "description": "Execute all executable cards in a dashboard with optional dashboard-level filters and consolidated per-card results."
     },
     {
       "name": "export",

--- a/src/handlers/executeDashboard/index.ts
+++ b/src/handlers/executeDashboard/index.ts
@@ -16,6 +16,7 @@ import {
   DashboardParameterInfo,
   DashboardCardExecutionError,
   ExecuteDashboardRequest,
+  ExecuteDashboardMode,
   ExecutableDashcard,
   SkippedDashcard,
 } from './types.js';
@@ -24,6 +25,42 @@ import { normalizeCardResponseData } from './normalizers.js';
 
 const DEFAULT_ROW_LIMIT = 100;
 const EXECUTION_CONCURRENCY = 3;
+
+interface FilterIssue {
+  code: 'unknown_filter_slug' | 'unmapped_filter_slug' | 'invalid_target_mapping';
+  filter_slug: string;
+  message: string;
+}
+
+interface FilterMappingEntry {
+  filter_slug: string;
+  dashboard_parameter_id: string | null;
+  dashboard_parameter_name: string | null;
+  dashboard_parameter_type: string | null;
+  mapped_dashcards: number;
+  mapped_cards: number;
+  mapped_targets: Array<{ target_type: string; parameter_type: string }>;
+  status: 'mapped' | 'blocked';
+  issues: FilterIssue[];
+}
+
+interface PreflightInsights {
+  warnings: string[];
+  blockingIssues: FilterIssue[];
+  unmatchedFilterSlugs: string[];
+  matchedFilterSlugs: string[];
+  suggestedFilterPayload: Record<string, DashboardFilterValue>;
+  filterMappingMatrix: FilterMappingEntry[];
+  filterSlugsByDashcardId: Map<number, string[]>;
+  dashcardSummaries: Array<{
+    dashcard_id: number;
+    card_id: number;
+    card_name: string;
+    has_parameter_mappings: boolean;
+    mapped_filter_slugs: string[];
+    mapped_filter_count: number;
+  }>;
+}
 
 function parseDashboardIdFromUrl(urlString: string): number | null {
   try {
@@ -46,6 +83,60 @@ function parseDashboardIdFromUrl(urlString: string): number | null {
   } catch {
     return null;
   }
+}
+
+function isValidMetabaseTarget(target: unknown): target is [string, [string, string]] {
+  if (!Array.isArray(target) || target.length !== 2) {
+    return false;
+  }
+
+  if (typeof target[0] !== 'string') {
+    return false;
+  }
+
+  if (!Array.isArray(target[1]) || target[1].length !== 2) {
+    return false;
+  }
+
+  return typeof target[1][0] === 'string' && typeof target[1][1] === 'string';
+}
+
+function normalizeDashboardMode(
+  rawMode: unknown,
+  requestId: string,
+  logWarn: (message: string, data?: unknown, error?: Error) => void
+): ExecuteDashboardMode {
+  if (rawMode === undefined) {
+    return 'execute';
+  }
+
+  if (rawMode === 'discover' || rawMode === 'execute') {
+    return rawMode;
+  }
+
+  logWarn('Invalid mode parameter for execute_dashboard', { requestId, rawMode });
+  throw new McpError(ErrorCode.InvalidParams, 'mode must be either "discover" or "execute"');
+}
+
+function normalizeStrictFilters(
+  rawStrictFilters: unknown,
+  mode: ExecuteDashboardMode,
+  requestId: string,
+  logWarn: (message: string, data?: unknown, error?: Error) => void
+): boolean {
+  if (rawStrictFilters === undefined) {
+    return mode === 'execute';
+  }
+
+  if (typeof rawStrictFilters !== 'boolean') {
+    logWarn('Invalid strict_filters parameter - must be a boolean', {
+      requestId,
+      rawStrictFilters,
+    });
+    throw new McpError(ErrorCode.InvalidParams, 'strict_filters parameter must be a boolean');
+  }
+
+  return rawStrictFilters;
 }
 
 function normalizeDashboardFilters(
@@ -186,6 +277,169 @@ function categorizeDashcards(dashboard: any): {
   return { executable, skipped };
 }
 
+function buildPreflightInsights(
+  dashboardFilters: Record<string, DashboardFilterValue>,
+  parameterBySlug: Map<string, DashboardParameterInfo>,
+  executableDashcards: ExecutableDashcard[]
+): PreflightInsights {
+  const warnings = new Set<string>();
+  const blockingIssues: FilterIssue[] = [];
+  const unmatchedFilterSlugs: string[] = [];
+  const matchedFilterSlugs = new Set<string>();
+  const suggestedFilterPayload: Record<string, DashboardFilterValue> = { ...dashboardFilters };
+  const filterMappingMatrix: FilterMappingEntry[] = [];
+  const filterSlugsByDashcard = new Map<number, Set<string>>();
+
+  executableDashcards.forEach(card => {
+    filterSlugsByDashcard.set(card.dashcardId, new Set<string>());
+  });
+
+  for (const [slug, value] of Object.entries(dashboardFilters)) {
+    const parameterInfo = parameterBySlug.get(slug);
+    if (!parameterInfo) {
+      const issue: FilterIssue = {
+        code: 'unknown_filter_slug',
+        filter_slug: slug,
+        message: `Provided filter slug "${slug}" was not found in dashboard parameters`,
+      };
+
+      blockingIssues.push(issue);
+      unmatchedFilterSlugs.push(slug);
+      filterMappingMatrix.push({
+        filter_slug: slug,
+        dashboard_parameter_id: null,
+        dashboard_parameter_name: null,
+        dashboard_parameter_type: null,
+        mapped_dashcards: 0,
+        mapped_cards: 0,
+        mapped_targets: [],
+        status: 'blocked',
+        issues: [issue],
+      });
+      continue;
+    }
+
+    const validMappings: Array<{
+      dashcardId: number;
+      cardId: number;
+      target: [string, [string, string]];
+      type: string;
+    }> = [];
+    let invalidMappingCount = 0;
+
+    for (const card of executableDashcards) {
+      const mappingsForParameter = card.parameterMappings.filter(
+        (mapping: any) => String(mapping?.parameter_id ?? '') === parameterInfo.id
+      );
+
+      for (const mapping of mappingsForParameter) {
+        const target = (mapping as any)?.target;
+        if (!isValidMetabaseTarget(target)) {
+          invalidMappingCount += 1;
+          continue;
+        }
+
+        validMappings.push({
+          dashcardId: card.dashcardId,
+          cardId: card.cardId,
+          target,
+          type: parameterInfo.type,
+        });
+        const cardFilters = filterSlugsByDashcard.get(card.dashcardId);
+        cardFilters?.add(slug);
+      }
+    }
+
+    const issues: FilterIssue[] = [];
+
+    if (validMappings.length === 0) {
+      const issue: FilterIssue = {
+        code: invalidMappingCount > 0 ? 'invalid_target_mapping' : 'unmapped_filter_slug',
+        filter_slug: slug,
+        message:
+          invalidMappingCount > 0
+            ? `Filter "${slug}" has mappings, but all mapped targets are invalid`
+            : `Filter "${slug}" is defined on the dashboard but does not map to executable cards`,
+      };
+
+      blockingIssues.push(issue);
+      unmatchedFilterSlugs.push(slug);
+      issues.push(issue);
+    } else {
+      matchedFilterSlugs.add(slug);
+      if (
+        validMappings.some(mapping => mapping.target[0] === 'dimension') &&
+        !Array.isArray(value)
+      ) {
+        suggestedFilterPayload[slug] = [value];
+      }
+    }
+
+    if (invalidMappingCount > 0) {
+      warnings.add(
+        `Filter "${slug}" has ${invalidMappingCount} invalid parameter mapping target(s)`
+      );
+    }
+
+    const uniqueDashcardIds = new Set(validMappings.map(mapping => mapping.dashcardId));
+    const uniqueCardIds = new Set(validMappings.map(mapping => mapping.cardId));
+    const targetKeySet = new Set(
+      validMappings.map(mapping => `${mapping.target[0]}|${mapping.type}`)
+    );
+
+    filterMappingMatrix.push({
+      filter_slug: slug,
+      dashboard_parameter_id: parameterInfo.id,
+      dashboard_parameter_name: parameterInfo.name,
+      dashboard_parameter_type: parameterInfo.type,
+      mapped_dashcards: uniqueDashcardIds.size,
+      mapped_cards: uniqueCardIds.size,
+      mapped_targets: Array.from(targetKeySet).map(key => {
+        const [targetType, parameterType] = key.split('|');
+        return { target_type: targetType, parameter_type: parameterType };
+      }),
+      status: issues.length > 0 ? 'blocked' : 'mapped',
+      issues,
+    });
+  }
+
+  const filterSlugsByDashcardId = new Map<number, string[]>();
+  const dashcardSummaries = executableDashcards.map(card => {
+    const mappedFilterSlugs = Array.from(filterSlugsByDashcard.get(card.dashcardId) || []).sort();
+    filterSlugsByDashcardId.set(card.dashcardId, mappedFilterSlugs);
+
+    return {
+      dashcard_id: card.dashcardId,
+      card_id: card.cardId,
+      card_name: card.cardName,
+      has_parameter_mappings: card.parameterMappings.length > 0,
+      mapped_filter_slugs: mappedFilterSlugs,
+      mapped_filter_count: mappedFilterSlugs.length,
+    };
+  });
+
+  return {
+    warnings: Array.from(warnings),
+    blockingIssues,
+    unmatchedFilterSlugs,
+    matchedFilterSlugs: Array.from(matchedFilterSlugs).sort(),
+    suggestedFilterPayload,
+    filterMappingMatrix,
+    filterSlugsByDashcardId,
+    dashcardSummaries,
+  };
+}
+
+function createStrictFiltersErrorMessage(
+  blockingIssues: FilterIssue[],
+  availableFilterSlugs: string[]
+): string {
+  const issueSummary = blockingIssues.map(issue => `${issue.filter_slug}:${issue.code}`).join(', ');
+  const available = availableFilterSlugs.length > 0 ? availableFilterSlugs.join(', ') : '(none)';
+
+  return `Dashboard filter validation failed (${issueSummary}). Available dashboard filter slugs: ${available}. Run execute_dashboard with mode="discover" to inspect mappings before execution.`;
+}
+
 async function runWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
@@ -229,6 +483,8 @@ export async function handleExecuteDashboard(
 
   const dashboardIdArg = args?.dashboard_id;
   const dashboardUrlArg = args?.dashboard_url;
+  const mode = normalizeDashboardMode(args?.mode, requestId, logWarn);
+  const strictFilters = normalizeStrictFilters(args?.strict_filters, mode, requestId, logWarn);
   const rowLimitArg = args?.row_limit;
   const rowLimit = typeof rowLimitArg === 'number' ? rowLimitArg : DEFAULT_ROW_LIMIT;
   const dashboardFilters = normalizeDashboardFilters(args?.dashboard_filters, requestId, logWarn);
@@ -277,8 +533,9 @@ export async function handleExecuteDashboard(
     dashboardId = parsedDashboardId;
   }
 
-  logDebug(`Executing dashboard ${dashboardId} with row limit: ${rowLimit}`, {
+  logDebug(`Preparing dashboard ${dashboardId} in ${mode} mode with row limit: ${rowLimit}`, {
     filterCount: Object.keys(dashboardFilters).length,
+    strictFilters,
   });
 
   try {
@@ -289,19 +546,78 @@ export async function handleExecuteDashboard(
         ? dashboard.name
         : `dashboard_${dashboardId}`;
 
-    const warnings = new Set<string>();
     const parameterBySlug = extractDashboardParameters(dashboard);
-    const unmatchedFilters: string[] = [];
+    const { executable, skipped } = categorizeDashcards(dashboard);
+    const preflight = buildPreflightInsights(dashboardFilters, parameterBySlug, executable);
 
-    for (const slug of Object.keys(dashboardFilters)) {
-      if (!parameterBySlug.has(slug)) {
-        warnings.add(`Dashboard filter "${slug}" was not found in dashboard parameters`);
-        unmatchedFilters.push(slug);
-      }
+    if (mode === 'discover') {
+      const response = {
+        success: true,
+        mode,
+        dashboard: {
+          id: dashboardId,
+          name: dashboardName,
+          source: dashboardResponse.source,
+          total_dashcards: executable.length + skipped.length,
+          executable_dashcards: executable.length,
+          skipped_cards: skipped.length,
+        },
+        applied_filters: dashboardFilters,
+        filter_resolution: {
+          provided_filter_slugs: Object.keys(dashboardFilters),
+          matched_filter_slugs: preflight.matchedFilterSlugs,
+          unmatched_filter_slugs: preflight.unmatchedFilterSlugs,
+          available_dashboard_filters: Array.from(parameterBySlug.values()).map(param => ({
+            id: param.id,
+            slug: param.slug,
+            name: param.name,
+            type: param.type,
+          })),
+        },
+        filter_mapping_matrix: preflight.filterMappingMatrix,
+        dashcards: preflight.dashcardSummaries,
+        execution_readiness: {
+          ready: preflight.blockingIssues.length === 0,
+          blocking_issues: preflight.blockingIssues,
+          warnings: preflight.warnings,
+          suggested_filter_payload: preflight.suggestedFilterPayload,
+        },
+        skipped,
+        usage_guidance:
+          'Use mode="execute" with suggested_filter_payload to run cards after readiness is true.',
+        retrieved_at: new Date().toISOString(),
+      };
+
+      logInfo(
+        `Dashboard discover complete for ${dashboardId}: ready=${response.execution_readiness.ready}`,
+        { requestId }
+      );
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: formatJson(response),
+          },
+        ],
+      };
     }
 
-    const { executable, skipped } = categorizeDashcards(dashboard);
+    if (strictFilters && preflight.blockingIssues.length > 0) {
+      const availableFilterSlugs = Array.from(parameterBySlug.keys()).sort();
+      const strictErrorMessage = createStrictFiltersErrorMessage(
+        preflight.blockingIssues,
+        availableFilterSlugs
+      );
+      logWarn('execute_dashboard strict filter validation failed', {
+        requestId,
+        dashboardId,
+        blockingIssues: preflight.blockingIssues,
+      });
+      throw new McpError(ErrorCode.InvalidParams, strictErrorMessage);
+    }
 
+    const warnings = new Set<string>(preflight.warnings);
     const errors: DashboardCardExecutionError[] = [];
     const cards: any[] = [];
 
@@ -369,7 +685,7 @@ export async function handleExecuteDashboard(
               row_count: normalized.rowCount,
               original_row_count: normalized.originalRowCount,
               applied_limit: rowLimit,
-              applied_filters: normalizedCardParameters.map(param => param.slug),
+              applied_filters: preflight.filterSlugsByDashcardId.get(card.dashcardId) || [],
               applied_parameter_count: normalizedCardParameters.length,
               data: normalized.data,
             },
@@ -408,6 +724,8 @@ export async function handleExecuteDashboard(
 
     const response = {
       success: true,
+      mode,
+      strict_filters: strictFilters,
       dashboard: {
         id: dashboardId,
         name: dashboardName,
@@ -421,11 +739,10 @@ export async function handleExecuteDashboard(
       applied_filters: dashboardFilters,
       filter_resolution: {
         provided_filter_slugs: Object.keys(dashboardFilters),
-        matched_filter_slugs: Object.keys(dashboardFilters).filter(
-          slug => !unmatchedFilters.includes(slug)
-        ),
-        unmatched_filter_slugs: unmatchedFilters,
+        matched_filter_slugs: preflight.matchedFilterSlugs,
+        unmatched_filter_slugs: preflight.unmatchedFilterSlugs,
         available_dashboard_filters: Array.from(parameterBySlug.values()).map(param => ({
+          id: param.id,
           slug: param.slug,
           name: param.name,
           type: param.type,
@@ -436,7 +753,7 @@ export async function handleExecuteDashboard(
       errors,
       cards,
       usage_guidance:
-        'This response mirrors dashboard-style execution in API context. For very large cards or dashboards, reduce row_limit or run execute/export on specific card IDs.',
+        'For reliable filtering, run mode="discover" first and then execute with suggested_filter_payload.',
       retrieved_at: new Date().toISOString(),
     };
 
@@ -457,7 +774,7 @@ export async function handleExecuteDashboard(
     throw handleApiError(
       error,
       {
-        operation: 'Execute dashboard',
+        operation: mode === 'discover' ? 'Discover dashboard' : 'Execute dashboard',
         resourceType: 'dashboard',
         resourceId: dashboardId,
       },

--- a/src/handlers/executeDashboard/index.ts
+++ b/src/handlers/executeDashboard/index.ts
@@ -8,7 +8,6 @@ import {
   validateMetabaseResponse,
   formatJson,
   normalizeCardParametersForMetabase,
-  validateCardParameters,
 } from '../../utils/index.js';
 import {
   DashboardExecutionResponse,
@@ -85,20 +84,62 @@ function parseDashboardIdFromUrl(urlString: string): number | null {
   }
 }
 
-function isValidMetabaseTarget(target: unknown): target is [string, [string, string]] {
-  if (!Array.isArray(target) || target.length !== 2) {
+function isValidMetabaseTarget(target: unknown): target is [string, ...unknown[]] {
+  if (!Array.isArray(target) || target.length === 0) {
     return false;
   }
 
-  if (typeof target[0] !== 'string') {
-    return false;
+  return typeof target[0] === 'string';
+}
+
+function extractDashboardFiltersFromUrl(urlString: string): Record<string, DashboardFilterValue> {
+  try {
+    const parsedUrl = new URL(urlString);
+    const extracted: Record<string, DashboardFilterValue> = {};
+    const uniqueKeys = new Set(parsedUrl.searchParams.keys());
+
+    uniqueKeys.forEach(key => {
+      if (!key || key.trim() === '') {
+        return;
+      }
+
+      const values = parsedUrl.searchParams
+        .getAll(key)
+        .map(value => value.trim())
+        .filter(value => value !== '');
+
+      if (values.length === 0) {
+        return;
+      }
+
+      extracted[key] = values.length === 1 ? values[0] : values;
+    });
+
+    return extracted;
+  } catch {
+    return {};
+  }
+}
+
+function mergeRawDashboardFilters(
+  argFilters: unknown,
+  dashboardUrlArg: unknown
+): Record<string, DashboardFilterValue> | unknown {
+  const urlFilters =
+    typeof dashboardUrlArg === 'string' ? extractDashboardFiltersFromUrl(dashboardUrlArg) : {};
+
+  if (argFilters === undefined) {
+    return Object.keys(urlFilters).length > 0 ? urlFilters : undefined;
   }
 
-  if (!Array.isArray(target[1]) || target[1].length !== 2) {
-    return false;
+  if (!argFilters || typeof argFilters !== 'object' || Array.isArray(argFilters)) {
+    return argFilters;
   }
 
-  return typeof target[1][0] === 'string' && typeof target[1][1] === 'string';
+  return {
+    ...urlFilters,
+    ...(argFilters as Record<string, DashboardFilterValue>),
+  };
 }
 
 function normalizeDashboardMode(
@@ -322,7 +363,7 @@ function buildPreflightInsights(
     const validMappings: Array<{
       dashcardId: number;
       cardId: number;
-      target: [string, [string, string]];
+      target: [string, ...unknown[]];
       type: string;
     }> = [];
     let invalidMappingCount = 0;
@@ -352,20 +393,36 @@ function buildPreflightInsights(
 
     const issues: FilterIssue[] = [];
 
+    if (invalidMappingCount > 0) {
+      const issue: FilterIssue = {
+        code: 'invalid_target_mapping',
+        filter_slug: slug,
+        message: `Filter "${slug}" has ${invalidMappingCount} invalid mapping target(s)`,
+      };
+
+      issues.push(issue);
+      blockingIssues.push(issue);
+      unmatchedFilterSlugs.push(slug);
+      warnings.add(
+        `Filter "${slug}" has ${invalidMappingCount} invalid parameter mapping target(s)`
+      );
+    }
+
     if (validMappings.length === 0) {
       const issue: FilterIssue = {
-        code: invalidMappingCount > 0 ? 'invalid_target_mapping' : 'unmapped_filter_slug',
+        code: 'unmapped_filter_slug',
         filter_slug: slug,
-        message:
-          invalidMappingCount > 0
-            ? `Filter "${slug}" has mappings, but all mapped targets are invalid`
-            : `Filter "${slug}" is defined on the dashboard but does not map to executable cards`,
+        message: `Filter "${slug}" is defined on the dashboard but does not map to executable cards`,
       };
 
       blockingIssues.push(issue);
-      unmatchedFilterSlugs.push(slug);
+      if (!unmatchedFilterSlugs.includes(slug)) {
+        unmatchedFilterSlugs.push(slug);
+      }
       issues.push(issue);
-    } else {
+    }
+
+    if (issues.length === 0) {
       matchedFilterSlugs.add(slug);
       if (
         validMappings.some(mapping => mapping.target[0] === 'dimension') &&
@@ -373,12 +430,6 @@ function buildPreflightInsights(
       ) {
         suggestedFilterPayload[slug] = [value];
       }
-    }
-
-    if (invalidMappingCount > 0) {
-      warnings.add(
-        `Filter "${slug}" has ${invalidMappingCount} invalid parameter mapping target(s)`
-      );
     }
 
     const uniqueDashcardIds = new Set(validMappings.map(mapping => mapping.dashcardId));
@@ -487,7 +538,8 @@ export async function handleExecuteDashboard(
   const strictFilters = normalizeStrictFilters(args?.strict_filters, mode, requestId, logWarn);
   const rowLimitArg = args?.row_limit;
   const rowLimit = typeof rowLimitArg === 'number' ? rowLimitArg : DEFAULT_ROW_LIMIT;
-  const dashboardFilters = normalizeDashboardFilters(args?.dashboard_filters, requestId, logWarn);
+  const rawDashboardFilters = mergeRawDashboardFilters(args?.dashboard_filters, dashboardUrlArg);
+  const dashboardFilters = normalizeDashboardFilters(rawDashboardFilters, requestId, logWarn);
 
   if (dashboardIdArg === undefined && dashboardUrlArg === undefined) {
     logWarn('Missing required parameters: dashboard_id or dashboard_url must be provided', {
@@ -636,22 +688,6 @@ export async function handleExecuteDashboard(
         const normalizedCardParameters = normalizeCardParametersForMetabase(
           mappingResult.cardParameters
         );
-
-        if (normalizedCardParameters.length > 0) {
-          try {
-            validateCardParameters(normalizedCardParameters, requestId, logWarn);
-          } catch (error: any) {
-            return {
-              status: 'error' as const,
-              error: {
-                dashcard_id: card.dashcardId,
-                card_id: card.cardId,
-                card_name: card.cardName,
-                error: `Invalid mapped dashboard filters for card: ${error?.message || 'unknown validation error'}`,
-              },
-            };
-          }
-        }
 
         const requestBody = {
           parameters: normalizedCardParameters,

--- a/src/handlers/executeDashboard/index.ts
+++ b/src/handlers/executeDashboard/index.ts
@@ -1,0 +1,388 @@
+import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { MetabaseApiClient } from '../../api.js';
+import { ErrorCode, McpError } from '../../types/core.js';
+import {
+  handleApiError,
+  validatePositiveInteger,
+  validateRowLimit,
+  validateMetabaseResponse,
+  formatJson,
+} from '../../utils/index.js';
+import {
+  DashboardExecutionResponse,
+  DashboardFilterValue,
+  DashboardParameterInfo,
+  DashboardCardExecutionError,
+  ExecuteDashboardRequest,
+  ExecutableDashcard,
+  SkippedDashcard,
+} from './types.js';
+import { mapDashboardFiltersToCardParameters } from './mapping.js';
+import { normalizeCardResponseData } from './normalizers.js';
+
+const DEFAULT_ROW_LIMIT = 100;
+const EXECUTION_CONCURRENCY = 3;
+
+function parseDashboardIdFromUrl(urlString: string): number | null {
+  try {
+    const parsedUrl = new URL(urlString);
+    const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
+    const dashboardSegmentIndex = pathSegments.findIndex(segment => segment === 'dashboard');
+
+    if (dashboardSegmentIndex === -1 || dashboardSegmentIndex === pathSegments.length - 1) {
+      return null;
+    }
+
+    const rawDashboardSegment = pathSegments[dashboardSegmentIndex + 1];
+    const idMatch = rawDashboardSegment.match(/^(\d+)/);
+    if (!idMatch) {
+      return null;
+    }
+
+    const dashboardId = parseInt(idMatch[1], 10);
+    return Number.isInteger(dashboardId) && dashboardId > 0 ? dashboardId : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDashboardFilters(
+  rawFilters: unknown,
+  requestId: string,
+  logWarn: (message: string, data?: unknown, error?: Error) => void
+): Record<string, DashboardFilterValue> {
+  if (rawFilters === undefined) {
+    return {};
+  }
+
+  if (!rawFilters || typeof rawFilters !== 'object' || Array.isArray(rawFilters)) {
+    logWarn('Invalid dashboard_filters parameter - must be an object map', { requestId });
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'dashboard_filters must be an object map in the format {"filter_slug": value}'
+    );
+  }
+
+  const normalized: Record<string, DashboardFilterValue> = {};
+  for (const [slug, value] of Object.entries(rawFilters)) {
+    if (!slug || slug.trim() === '') {
+      logWarn('Invalid dashboard filter slug - cannot be empty', { requestId });
+      throw new McpError(ErrorCode.InvalidParams, 'dashboard filter slugs cannot be empty');
+    }
+
+    const valueType = typeof value;
+    if (valueType !== 'string' && valueType !== 'number' && valueType !== 'boolean') {
+      logWarn('Invalid dashboard filter value type', { requestId, slug, valueType });
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `dashboard_filters["${slug}"] must be a string, number, or boolean`
+      );
+    }
+
+    normalized[slug] = value as DashboardFilterValue;
+  }
+
+  return normalized;
+}
+
+function extractDashboardParameters(dashboard: any): Map<string, DashboardParameterInfo> {
+  const parameterBySlug = new Map<string, DashboardParameterInfo>();
+  const dashboardParameters = Array.isArray(dashboard?.parameters) ? dashboard.parameters : [];
+
+  dashboardParameters.forEach((param: any) => {
+    if (param?.slug && param?.id !== undefined && param?.id !== null) {
+      parameterBySlug.set(param.slug, {
+        id: String(param.id),
+        slug: String(param.slug),
+        type: typeof param.type === 'string' ? param.type : 'text',
+      });
+    }
+  });
+
+  return parameterBySlug;
+}
+
+function categorizeDashcards(dashboard: any): {
+  executable: ExecutableDashcard[];
+  skipped: SkippedDashcard[];
+} {
+  const dashcards = Array.isArray(dashboard?.dashcards) ? dashboard.dashcards : [];
+  const executable: ExecutableDashcard[] = [];
+  const skipped: SkippedDashcard[] = [];
+
+  for (const dashcard of dashcards) {
+    const dashcardId = typeof dashcard?.id === 'number' ? dashcard.id : null;
+    const cardId = typeof dashcard?.card_id === 'number' ? dashcard.card_id : null;
+    const cardName =
+      typeof dashcard?.card?.name === 'string' && dashcard.card.name.trim() !== ''
+        ? dashcard.card.name
+        : cardId !== null
+          ? `card_${cardId}`
+          : 'unknown';
+
+    if (!dashcardId || !cardId) {
+      skipped.push({
+        dashcard_id: dashcardId,
+        card_id: cardId,
+        reason: 'non-executable dashcard (missing dashcard id or card id)',
+      });
+      continue;
+    }
+
+    executable.push({
+      dashcardId,
+      cardId,
+      cardName,
+      parameterMappings: Array.isArray(dashcard?.parameter_mappings)
+        ? dashcard.parameter_mappings
+        : [],
+    });
+  }
+
+  return { executable, skipped };
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex++;
+
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      results[currentIndex] = await task(items[currentIndex]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export async function handleExecuteDashboard(
+  request: CallToolRequest,
+  requestId: string,
+  apiClient: MetabaseApiClient,
+  logDebug: (message: string, data?: unknown) => void,
+  logInfo: (message: string, data?: unknown) => void,
+  logWarn: (message: string, data?: unknown, error?: Error) => void,
+  logError: (message: string, error: unknown) => void
+): Promise<DashboardExecutionResponse> {
+  const args = request.params?.arguments as ExecuteDashboardRequest;
+
+  const dashboardIdArg = args?.dashboard_id;
+  const dashboardUrlArg = args?.dashboard_url;
+  const rowLimitArg = args?.row_limit;
+  const rowLimit = typeof rowLimitArg === 'number' ? rowLimitArg : DEFAULT_ROW_LIMIT;
+  const dashboardFilters = normalizeDashboardFilters(args?.dashboard_filters, requestId, logWarn);
+
+  if (dashboardIdArg === undefined && dashboardUrlArg === undefined) {
+    logWarn('Missing required parameters: dashboard_id or dashboard_url must be provided', {
+      requestId,
+    });
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'Either dashboard_id or dashboard_url parameter is required'
+    );
+  }
+
+  if (dashboardIdArg !== undefined && typeof dashboardIdArg !== 'number') {
+    logWarn('Invalid dashboard_id parameter - must be a number', { requestId });
+    throw new McpError(ErrorCode.InvalidParams, 'dashboard_id parameter must be a number');
+  }
+
+  if (dashboardUrlArg !== undefined && typeof dashboardUrlArg !== 'string') {
+    logWarn('Invalid dashboard_url parameter - must be a string', { requestId });
+    throw new McpError(ErrorCode.InvalidParams, 'dashboard_url parameter must be a string');
+  }
+
+  validateRowLimit(rowLimit, 'row_limit', requestId, logWarn);
+
+  let dashboardId: number;
+  if (dashboardIdArg !== undefined) {
+    validatePositiveInteger(dashboardIdArg, 'dashboard_id', requestId, logWarn);
+    dashboardId = dashboardIdArg;
+
+    if (dashboardUrlArg) {
+      logWarn('Both dashboard_id and dashboard_url were provided; dashboard_id takes precedence', {
+        requestId,
+      });
+    }
+  } else {
+    const parsedDashboardId = parseDashboardIdFromUrl((dashboardUrlArg || '').trim());
+    if (!parsedDashboardId) {
+      logWarn('Could not parse dashboard ID from dashboard_url', { requestId, dashboardUrlArg });
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'dashboard_url must be a valid Metabase app dashboard URL containing a numeric dashboard ID'
+      );
+    }
+    dashboardId = parsedDashboardId;
+  }
+
+  logDebug(`Executing dashboard ${dashboardId} with row limit: ${rowLimit}`, {
+    filterCount: Object.keys(dashboardFilters).length,
+  });
+
+  try {
+    const dashboardResponse = await apiClient.getDashboard(dashboardId);
+    const dashboard = dashboardResponse.data;
+    const dashboardName =
+      typeof dashboard?.name === 'string' && dashboard.name.trim() !== ''
+        ? dashboard.name
+        : `dashboard_${dashboardId}`;
+
+    const warnings = new Set<string>();
+    const parameterBySlug = extractDashboardParameters(dashboard);
+
+    for (const slug of Object.keys(dashboardFilters)) {
+      if (!parameterBySlug.has(slug)) {
+        warnings.add(`Dashboard filter "${slug}" was not found in dashboard parameters`);
+      }
+    }
+
+    const { executable, skipped } = categorizeDashcards(dashboard);
+
+    const errors: DashboardCardExecutionError[] = [];
+    const cards: any[] = [];
+
+    const executionResults = await runWithConcurrency(
+      executable,
+      EXECUTION_CONCURRENCY,
+      async card => {
+        const mappingResult = mapDashboardFiltersToCardParameters(
+          card.dashcardId,
+          dashboardFilters,
+          card.parameterMappings,
+          parameterBySlug
+        );
+
+        mappingResult.warnings.forEach(warning => warnings.add(warning));
+
+        const requestBody = {
+          parameters: mappingResult.cardParameters,
+          pivot_results: false,
+          format_rows: false,
+        };
+
+        const endpoint = `/api/dashboard/${dashboardId}/dashcard/${card.dashcardId}/card/${card.cardId}/query`;
+
+        try {
+          const response = await apiClient.request<any>(endpoint, {
+            method: 'POST',
+            body: JSON.stringify(requestBody),
+          });
+
+          validateMetabaseResponse(
+            response,
+            { operation: 'Dashboard card execution', resourceId: card.cardId },
+            logError
+          );
+
+          const normalized = normalizeCardResponseData(response, rowLimit);
+
+          return {
+            status: 'success' as const,
+            card: {
+              dashcard_id: card.dashcardId,
+              card_id: card.cardId,
+              card_name: card.cardName,
+              status: 'success',
+              row_count: normalized.rowCount,
+              original_row_count: normalized.originalRowCount,
+              applied_limit: rowLimit,
+              data: normalized.data,
+            },
+          };
+        } catch (error: any) {
+          const handledError = handleApiError(
+            error,
+            {
+              operation: 'Dashboard card execution',
+              resourceType: 'card',
+              resourceId: card.cardId,
+            },
+            logError
+          );
+
+          return {
+            status: 'error' as const,
+            error: {
+              dashcard_id: card.dashcardId,
+              card_id: card.cardId,
+              card_name: card.cardName,
+              error: handledError.message,
+            },
+          };
+        }
+      }
+    );
+
+    executionResults.forEach(result => {
+      if (result.status === 'success') {
+        cards.push(result.card);
+      } else {
+        errors.push(result.error);
+      }
+    });
+
+    const response = {
+      success: true,
+      dashboard: {
+        id: dashboardId,
+        name: dashboardName,
+        source: dashboardResponse.source,
+        total_dashcards: executable.length + skipped.length,
+        executable_dashcards: executable.length,
+        executed_cards: cards.length,
+        failed_cards: errors.length,
+        skipped_cards: skipped.length,
+      },
+      applied_filters: dashboardFilters,
+      warnings: Array.from(warnings),
+      skipped,
+      errors,
+      cards,
+      usage_guidance:
+        'This response mirrors dashboard-style execution in API context. For very large cards or dashboards, reduce row_limit or run execute/export on specific card IDs.',
+      retrieved_at: new Date().toISOString(),
+    };
+
+    logInfo(
+      `Dashboard execution complete for ${dashboardId}: ${cards.length} succeeded, ${errors.length} failed, ${skipped.length} skipped`,
+      { requestId }
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: formatJson(response),
+        },
+      ],
+    };
+  } catch (error: any) {
+    throw handleApiError(
+      error,
+      {
+        operation: 'Execute dashboard',
+        resourceType: 'dashboard',
+        resourceId: dashboardId,
+      },
+      logError
+    );
+  }
+}

--- a/src/handlers/executeDashboard/index.ts
+++ b/src/handlers/executeDashboard/index.ts
@@ -7,6 +7,8 @@ import {
   validateRowLimit,
   validateMetabaseResponse,
   formatJson,
+  normalizeCardParametersForMetabase,
+  validateCardParameters,
 } from '../../utils/index.js';
 import {
   DashboardExecutionResponse,
@@ -71,15 +73,53 @@ function normalizeDashboardFilters(
     }
 
     const valueType = typeof value;
-    if (valueType !== 'string' && valueType !== 'number' && valueType !== 'boolean') {
-      logWarn('Invalid dashboard filter value type', { requestId, slug, valueType });
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `dashboard_filters["${slug}"] must be a string, number, or boolean`
-      );
+    const isPrimitive = valueType === 'string' || valueType === 'number' || valueType === 'boolean';
+
+    if (isPrimitive) {
+      if (valueType === 'string' && (value as string).trim() === '') {
+        logWarn('Invalid dashboard filter value - string cannot be empty', { requestId, slug });
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `dashboard_filters["${slug}"] cannot be an empty string`
+        );
+      }
+      normalized[slug] = value as DashboardFilterValue;
+      continue;
     }
 
-    normalized[slug] = value as DashboardFilterValue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        logWarn('Invalid dashboard filter value - array cannot be empty', { requestId, slug });
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `dashboard_filters["${slug}"] cannot be an empty array`
+        );
+      }
+
+      const hasInvalidArrayItem = value.some(item => {
+        const itemType = typeof item;
+        const primitiveItem =
+          itemType === 'string' || itemType === 'number' || itemType === 'boolean';
+        return !primitiveItem || (itemType === 'string' && item.trim() === '');
+      });
+
+      if (hasInvalidArrayItem) {
+        logWarn('Invalid dashboard filter array value type', { requestId, slug });
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `dashboard_filters["${slug}"] must contain only non-empty string, number, or boolean values`
+        );
+      }
+
+      normalized[slug] = value as DashboardFilterValue;
+      continue;
+    }
+
+    logWarn('Invalid dashboard filter value type', { requestId, slug, valueType });
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `dashboard_filters["${slug}"] must be a string, number, boolean, or array of those values`
+    );
   }
 
   return normalized;
@@ -95,6 +135,10 @@ function extractDashboardParameters(dashboard: any): Map<string, DashboardParame
         id: String(param.id),
         slug: String(param.slug),
         type: typeof param.type === 'string' ? param.type : 'text',
+        name:
+          typeof param.name === 'string' && param.name.trim() !== ''
+            ? param.name
+            : String(param.slug),
       });
     }
   });
@@ -247,10 +291,12 @@ export async function handleExecuteDashboard(
 
     const warnings = new Set<string>();
     const parameterBySlug = extractDashboardParameters(dashboard);
+    const unmatchedFilters: string[] = [];
 
     for (const slug of Object.keys(dashboardFilters)) {
       if (!parameterBySlug.has(slug)) {
         warnings.add(`Dashboard filter "${slug}" was not found in dashboard parameters`);
+        unmatchedFilters.push(slug);
       }
     }
 
@@ -271,9 +317,28 @@ export async function handleExecuteDashboard(
         );
 
         mappingResult.warnings.forEach(warning => warnings.add(warning));
+        const normalizedCardParameters = normalizeCardParametersForMetabase(
+          mappingResult.cardParameters
+        );
+
+        if (normalizedCardParameters.length > 0) {
+          try {
+            validateCardParameters(normalizedCardParameters, requestId, logWarn);
+          } catch (error: any) {
+            return {
+              status: 'error' as const,
+              error: {
+                dashcard_id: card.dashcardId,
+                card_id: card.cardId,
+                card_name: card.cardName,
+                error: `Invalid mapped dashboard filters for card: ${error?.message || 'unknown validation error'}`,
+              },
+            };
+          }
+        }
 
         const requestBody = {
-          parameters: mappingResult.cardParameters,
+          parameters: normalizedCardParameters,
           pivot_results: false,
           format_rows: false,
         };
@@ -304,6 +369,8 @@ export async function handleExecuteDashboard(
               row_count: normalized.rowCount,
               original_row_count: normalized.originalRowCount,
               applied_limit: rowLimit,
+              applied_filters: normalizedCardParameters.map(param => param.slug),
+              applied_parameter_count: normalizedCardParameters.length,
               data: normalized.data,
             },
           };
@@ -352,6 +419,18 @@ export async function handleExecuteDashboard(
         skipped_cards: skipped.length,
       },
       applied_filters: dashboardFilters,
+      filter_resolution: {
+        provided_filter_slugs: Object.keys(dashboardFilters),
+        matched_filter_slugs: Object.keys(dashboardFilters).filter(
+          slug => !unmatchedFilters.includes(slug)
+        ),
+        unmatched_filter_slugs: unmatchedFilters,
+        available_dashboard_filters: Array.from(parameterBySlug.values()).map(param => ({
+          slug: param.slug,
+          name: param.name,
+          type: param.type,
+        })),
+      },
       warnings: Array.from(warnings),
       skipped,
       errors,

--- a/src/handlers/executeDashboard/mapping.ts
+++ b/src/handlers/executeDashboard/mapping.ts
@@ -1,0 +1,81 @@
+import type { MetabaseCardParameter } from '../../utils/parameterValidation.js';
+import { DashboardFilterValue, DashboardParameterInfo } from './types.js';
+
+function isValidMetabaseTarget(target: unknown): target is [string, [string, string]] {
+  if (!Array.isArray(target) || target.length !== 2) {
+    return false;
+  }
+
+  if (typeof target[0] !== 'string') {
+    return false;
+  }
+
+  if (!Array.isArray(target[1]) || target[1].length !== 2) {
+    return false;
+  }
+
+  return typeof target[1][0] === 'string' && typeof target[1][1] === 'string';
+}
+
+interface CardMappingResult {
+  cardParameters: MetabaseCardParameter[];
+  warnings: string[];
+}
+
+/**
+ * Map dashboard-level filter values (slug->value) into card parameters
+ * using dashcard parameter mappings.
+ */
+export function mapDashboardFiltersToCardParameters(
+  dashcardId: number,
+  dashboardFilters: Record<string, DashboardFilterValue>,
+  parameterMappings: unknown[],
+  dashboardParameterBySlug: Map<string, DashboardParameterInfo>
+): CardMappingResult {
+  const warnings = new Set<string>();
+  const cardParameters: MetabaseCardParameter[] = [];
+
+  if (Object.keys(dashboardFilters).length === 0) {
+    return { cardParameters, warnings: [] };
+  }
+
+  const safeMappings = Array.isArray(parameterMappings) ? parameterMappings : [];
+
+  for (const [slug, value] of Object.entries(dashboardFilters)) {
+    const dashboardParam = dashboardParameterBySlug.get(slug);
+    if (!dashboardParam) {
+      continue;
+    }
+
+    const mappedTargets = safeMappings.filter(
+      (mapping: any) => String(mapping?.parameter_id ?? '') === dashboardParam.id
+    );
+
+    if (mappedTargets.length === 0) {
+      warnings.add(
+        `Dashcard ${dashcardId} has no parameter mapping for dashboard filter "${slug}"`
+      );
+      continue;
+    }
+
+    for (const mapping of mappedTargets) {
+      const target = (mapping as any)?.target;
+      if (!isValidMetabaseTarget(target)) {
+        warnings.add(
+          `Dashcard ${dashcardId} has invalid target mapping for dashboard filter "${slug}"`
+        );
+        continue;
+      }
+
+      cardParameters.push({
+        id: dashboardParam.id,
+        slug: dashboardParam.slug,
+        type: dashboardParam.type,
+        target,
+        value,
+      });
+    }
+  }
+
+  return { cardParameters, warnings: Array.from(warnings) };
+}

--- a/src/handlers/executeDashboard/mapping.ts
+++ b/src/handlers/executeDashboard/mapping.ts
@@ -1,20 +1,12 @@
 import type { MetabaseCardParameter } from '../../utils/parameterValidation.js';
 import { DashboardFilterValue, DashboardParameterInfo } from './types.js';
 
-function isValidMetabaseTarget(target: unknown): target is [string, [string, string]] {
-  if (!Array.isArray(target) || target.length !== 2) {
+function isValidMetabaseTarget(target: unknown): target is [string, ...unknown[]] {
+  if (!Array.isArray(target) || target.length === 0) {
     return false;
   }
 
-  if (typeof target[0] !== 'string') {
-    return false;
-  }
-
-  if (!Array.isArray(target[1]) || target[1].length !== 2) {
-    return false;
-  }
-
-  return typeof target[1][0] === 'string' && typeof target[1][1] === 'string';
+  return typeof target[0] === 'string';
 }
 
 interface CardMappingResult {

--- a/src/handlers/executeDashboard/mapping.ts
+++ b/src/handlers/executeDashboard/mapping.ts
@@ -52,9 +52,6 @@ export function mapDashboardFiltersToCardParameters(
     );
 
     if (mappedTargets.length === 0) {
-      warnings.add(
-        `Dashcard ${dashcardId} has no parameter mapping for dashboard filter "${slug}"`
-      );
       continue;
     }
 

--- a/src/handlers/executeDashboard/normalizers.ts
+++ b/src/handlers/executeDashboard/normalizers.ts
@@ -1,0 +1,69 @@
+export interface NormalizedCardData {
+  rowCount: number;
+  originalRowCount: number;
+  data: unknown;
+}
+
+/**
+ * Normalize Metabase response payloads to consistently enforce row limits.
+ * Supports row+cols, numbered-key, and array result formats.
+ */
+export function normalizeCardResponseData(response: any, rowLimit: number): NormalizedCardData {
+  // Numbered-key format: {"0": {...}, "1": {...}, "data": {...}}
+  const numberedKeys = Object.keys(response || {})
+    .filter(key => /^\d+$/.test(key))
+    .sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
+
+  if (numberedKeys.length > 0) {
+    const originalRowCount = numberedKeys.length;
+    const limitedKeys = numberedKeys.slice(0, rowLimit);
+    const limitedData = { ...response };
+
+    numberedKeys.forEach(key => {
+      if (!limitedKeys.includes(key)) {
+        delete limitedData[key];
+      }
+    });
+
+    return {
+      rowCount: Math.min(originalRowCount, rowLimit),
+      originalRowCount,
+      data: limitedData,
+    };
+  }
+
+  // Standard row+cols format: {"data": {"rows": [...], "cols": [...]}}
+  if (response?.data?.rows && Array.isArray(response.data.rows)) {
+    const originalRowCount = response.data.rows.length;
+    const limitedRows = response.data.rows.slice(0, rowLimit);
+
+    return {
+      rowCount: Math.min(originalRowCount, rowLimit),
+      originalRowCount,
+      data: {
+        ...response,
+        data: {
+          ...response.data,
+          rows: limitedRows,
+        },
+      },
+    };
+  }
+
+  // Plain array format: [{...}, {...}]
+  if (Array.isArray(response)) {
+    const originalRowCount = response.length;
+    const limitedRows = response.slice(0, rowLimit);
+    return {
+      rowCount: Math.min(originalRowCount, rowLimit),
+      originalRowCount,
+      data: limitedRows,
+    };
+  }
+
+  return {
+    rowCount: 0,
+    originalRowCount: 0,
+    data: response,
+  };
+}

--- a/src/handlers/executeDashboard/types.ts
+++ b/src/handlers/executeDashboard/types.ts
@@ -1,4 +1,5 @@
-export type DashboardFilterValue = string | number | boolean;
+export type DashboardFilterPrimitive = string | number | boolean;
+export type DashboardFilterValue = DashboardFilterPrimitive | DashboardFilterPrimitive[];
 
 export interface ExecuteDashboardRequest {
   dashboard_id?: number;
@@ -18,6 +19,7 @@ export interface DashboardParameterInfo {
   id: string;
   slug: string;
   type: string;
+  name: string;
 }
 
 export interface ExecutableDashcard {

--- a/src/handlers/executeDashboard/types.ts
+++ b/src/handlers/executeDashboard/types.ts
@@ -1,11 +1,14 @@
 export type DashboardFilterPrimitive = string | number | boolean;
 export type DashboardFilterValue = DashboardFilterPrimitive | DashboardFilterPrimitive[];
+export type ExecuteDashboardMode = 'discover' | 'execute';
 
 export interface ExecuteDashboardRequest {
   dashboard_id?: number;
   dashboard_url?: string;
   dashboard_filters?: Record<string, DashboardFilterValue>;
   row_limit?: number;
+  mode?: ExecuteDashboardMode;
+  strict_filters?: boolean;
 }
 
 export interface DashboardExecutionResponse {

--- a/src/handlers/executeDashboard/types.ts
+++ b/src/handlers/executeDashboard/types.ts
@@ -1,0 +1,41 @@
+export type DashboardFilterValue = string | number | boolean;
+
+export interface ExecuteDashboardRequest {
+  dashboard_id?: number;
+  dashboard_url?: string;
+  dashboard_filters?: Record<string, DashboardFilterValue>;
+  row_limit?: number;
+}
+
+export interface DashboardExecutionResponse {
+  content: Array<{
+    type: 'text';
+    text: string;
+  }>;
+}
+
+export interface DashboardParameterInfo {
+  id: string;
+  slug: string;
+  type: string;
+}
+
+export interface ExecutableDashcard {
+  dashcardId: number;
+  cardId: number;
+  cardName: string;
+  parameterMappings: unknown[];
+}
+
+export interface SkippedDashcard {
+  dashcard_id: number | null;
+  card_id: number | null;
+  reason: string;
+}
+
+export interface DashboardCardExecutionError {
+  dashcard_id: number;
+  card_id: number;
+  card_name: string;
+  error: string;
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,5 +1,6 @@
 export { handleList } from './list/index.js';
 export { handleExecute } from './execute/index.js';
+export { handleExecuteDashboard } from './executeDashboard/index.js';
 export { handleExport } from './export/index.js';
 export { handleSearch } from './search.js';
 export { handleClearCache } from './clearCache.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -433,7 +433,7 @@ export class MetabaseServer {
           {
             name: 'execute_dashboard',
             description:
-              'Execute all executable cards in a dashboard using dashboard context and optional dashboard-level filter values. Accepts dashboard_id or dashboard_url, maps dashboard filters to card parameters, executes each dashcard, and returns normalized per-card data for discussion.',
+              'Discover dashboard filter mappings or execute all executable cards in a dashboard using dashboard context. Accepts dashboard_id or dashboard_url. Use mode="discover" first to inspect filter readiness, then mode="execute" to run cards.',
             annotations: {
               readOnlyHint: true,
               destructiveHint: false,
@@ -479,6 +479,18 @@ export class MetabaseServer {
                   default: 100,
                   minimum: 1,
                   maximum: 500,
+                },
+                mode: {
+                  type: 'string',
+                  enum: ['discover', 'execute'],
+                  description:
+                    'Operation mode: discover returns filter mappings and readiness without executing cards; execute runs dashboard cards.',
+                  default: 'execute',
+                },
+                strict_filters: {
+                  type: 'boolean',
+                  description:
+                    'When true, execute mode fails before card execution if any provided filter is unknown/unmapped/invalid. Defaults to true in execute mode.',
                 },
               },
               required: [],

--- a/src/server.ts
+++ b/src/server.ts
@@ -456,9 +456,20 @@ export class MetabaseServer {
                 dashboard_filters: {
                   type: 'object',
                   description:
-                    'Dashboard-level filter values as slug-to-value map. Values must be string, number, or boolean.',
+                    'Dashboard-level filter values as slug-to-value map. Values may be string, number, boolean, or arrays of those values.',
                   additionalProperties: {
-                    type: ['string', 'number', 'boolean'],
+                    anyOf: [
+                      { type: 'string' },
+                      { type: 'number' },
+                      { type: 'boolean' },
+                      {
+                        type: 'array',
+                        items: {
+                          type: ['string', 'number', 'boolean'],
+                        },
+                        minItems: 1,
+                      },
+                    ],
                   },
                 },
                 row_limit: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { MetabaseApiClient } from './api.js';
 import {
   handleList,
   handleExecute,
+  handleExecuteDashboard,
   handleExport,
   handleSearch,
   handleClearCache,
@@ -430,6 +431,49 @@ export class MetabaseServer {
             },
           },
           {
+            name: 'execute_dashboard',
+            description:
+              'Execute all executable cards in a dashboard using dashboard context and optional dashboard-level filter values. Accepts dashboard_id or dashboard_url, maps dashboard filters to card parameters, executes each dashcard, and returns normalized per-card data for discussion.',
+            annotations: {
+              readOnlyHint: true,
+              destructiveHint: false,
+              idempotentHint: false,
+              openWorldHint: true,
+            },
+            inputSchema: {
+              type: 'object',
+              properties: {
+                dashboard_id: {
+                  type: 'number',
+                  description:
+                    'Dashboard ID to execute. Provide this OR dashboard_url. If both are provided, dashboard_id takes precedence.',
+                },
+                dashboard_url: {
+                  type: 'string',
+                  description:
+                    'Metabase dashboard URL containing a numeric dashboard ID (for example: https://metabase.example.com/dashboard/123-my-dashboard).',
+                },
+                dashboard_filters: {
+                  type: 'object',
+                  description:
+                    'Dashboard-level filter values as slug-to-value map. Values must be string, number, or boolean.',
+                  additionalProperties: {
+                    type: ['string', 'number', 'boolean'],
+                  },
+                },
+                row_limit: {
+                  type: 'number',
+                  description:
+                    'Maximum number of rows to return per card (default: 100, max: 500).',
+                  default: 100,
+                  minimum: 1,
+                  maximum: 500,
+                },
+              },
+              required: [],
+            },
+          },
+          {
             name: 'clear_cache',
             description:
               'Clear the internal cache for stored data. Useful for debugging or when you know the data has changed. Supports granular cache clearing for both individual items and list caches.',
@@ -543,6 +587,19 @@ export class MetabaseServer {
         case 'export':
           return safeCall(() =>
             handleExport(
+              request,
+              requestId,
+              this.apiClient,
+              this.logDebug.bind(this),
+              this.logInfo.bind(this),
+              this.logWarn.bind(this),
+              this.logError.bind(this)
+            )
+          );
+
+        case 'execute_dashboard':
+          return safeCall(() =>
+            handleExecuteDashboard(
               request,
               requestId,
               this.apiClient,

--- a/src/server.ts
+++ b/src/server.ts
@@ -451,7 +451,7 @@ export class MetabaseServer {
                 dashboard_url: {
                   type: 'string',
                   description:
-                    'Metabase dashboard URL containing a numeric dashboard ID (for example: https://metabase.example.com/dashboard/123-my-dashboard).',
+                    'Metabase dashboard URL containing a numeric dashboard ID (for example: https://metabase.example.com/dashboard/123-my-dashboard). If dashboard_filters is omitted, query-string filters in the URL are used.',
                 },
                 dashboard_filters: {
                   type: 'object',

--- a/src/utils/parameterValidation.ts
+++ b/src/utils/parameterValidation.ts
@@ -4,7 +4,7 @@ import { validateNonEmptyString } from './validation.js';
 export interface MetabaseCardParameter {
   id: string;
   slug: string;
-  target: [string, [string, string]];
+  target: unknown;
   type: string;
   value: string | number | boolean | Array<string | number | boolean>;
 }

--- a/tests/handlers/executeDashboard.test.ts
+++ b/tests/handlers/executeDashboard.test.ts
@@ -188,6 +188,64 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
       expect(responseData.filter_mapping_matrix).toHaveLength(2);
       expect(mockApiClient.request).not.toHaveBeenCalled();
     });
+
+    it('should extract dashboard filters from dashboard_url query params when dashboard_filters is omitted', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_url: 'https://metabase.example.com/dashboard/321-test?date=2026-02-28&facility_name=Centro+M%C3%A9dico+Teknon',
+        mode: 'discover',
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 321,
+          name: 'Parsed Dashboard',
+          parameters: [
+            { id: 'param-date', slug: 'date', name: 'Date', type: 'date/single' },
+            { id: 'param-facility', slug: 'facility_name', name: 'Facility Name', type: 'string/=' },
+          ],
+          dashcards: [
+            {
+              id: 40,
+              card_id: 400,
+              card: { name: 'Card Numbered' },
+              parameter_mappings: [
+                {
+                  parameter_id: 'param-date',
+                  target: ['dimension', ['template-tag', 'month']],
+                },
+                {
+                  parameter_id: 'param-facility',
+                  target: ['dimension', ['template-tag', 'name']],
+                },
+              ],
+            },
+          ],
+        })
+      );
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.applied_filters).toEqual({
+        date: '2026-02-28',
+        facility_name: 'Centro Médico Teknon',
+      });
+      expect(responseData.filter_resolution.provided_filter_slugs).toEqual(['date', 'facility_name']);
+      expect(responseData.execution_readiness.ready).toBe(true);
+      expect(responseData.execution_readiness.suggested_filter_payload).toEqual({
+        date: ['2026-02-28'],
+        facility_name: ['Centro Médico Teknon'],
+      });
+    });
   });
 
   describe('Execute mode', () => {
@@ -206,6 +264,56 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
           name: 'Unknown Filter Dashboard',
           parameters: [],
           dashcards: [{ id: 30, card_id: 300, card: { name: 'Card A' }, parameter_mappings: [] }],
+        })
+      );
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow('Dashboard filter validation failed');
+
+      expect(mockApiClient.request).not.toHaveBeenCalled();
+    });
+
+    it('should fail fast when a provided filter has partially invalid target mappings', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 9,
+        dashboard_filters: {
+          facility_name: 'Centro Médico Teknon',
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 9,
+          name: 'Invalid Mapping Dashboard',
+          parameters: [
+            { id: 'param-facility', slug: 'facility_name', name: 'Facility Name', type: 'string/=' },
+          ],
+          dashcards: [
+            {
+              id: 90,
+              card_id: 900,
+              card: { name: 'Card A' },
+              parameter_mappings: [
+                { parameter_id: 'param-facility', target: ['dimension', ['template-tag', 'name']] },
+              ],
+            },
+            {
+              id: 91,
+              card_id: 901,
+              card: { name: 'Card B' },
+              parameter_mappings: [{ parameter_id: 'param-facility', target: null }],
+            },
+          ],
         })
       );
 

--- a/tests/handlers/executeDashboard.test.ts
+++ b/tests/handlers/executeDashboard.test.ts
@@ -42,9 +42,30 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
       );
     });
 
-    it('should throw error when dashboard_url cannot be parsed', async () => {
+    it('should throw error when mode is invalid', async () => {
       const request = createMockRequest('execute_dashboard', {
-        dashboard_url: 'https://metabase.example.com/dashboard/not-a-number',
+        dashboard_id: 1,
+        mode: 'bad-mode',
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow(McpError);
+    });
+
+    it('should throw error when strict_filters is not boolean', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 1,
+        strict_filters: 'true',
       });
       const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
 
@@ -65,28 +86,6 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
       const request = createMockRequest('execute_dashboard', {
         dashboard_id: 1,
         dashboard_filters: 'invalid',
-      });
-      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
-
-      await expect(
-        handleExecuteDashboard(
-          request as any,
-          'test-request-id',
-          mockApiClient as any,
-          logDebug,
-          logInfo,
-          logWarn,
-          logError
-        )
-      ).rejects.toThrow(McpError);
-    });
-
-    it('should throw error when dashboard filter value type is invalid', async () => {
-      const request = createMockRequest('execute_dashboard', {
-        dashboard_id: 1,
-        dashboard_filters: {
-          region: { invalid: true },
-        },
       });
       const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
 
@@ -126,7 +125,149 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
     });
   });
 
-  describe('Dashboard execution flow', () => {
+  describe('Discover mode', () => {
+    it('should return filter mapping readiness without executing cards', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 1,
+        mode: 'discover',
+        dashboard_filters: {
+          region: 'EMEA',
+          year: 2025,
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 1,
+          name: 'Revenue Dashboard',
+          parameters: [
+            {
+              id: 'param-region',
+              slug: 'region',
+              name: 'Region',
+              type: 'category',
+            },
+          ],
+          dashcards: [
+            {
+              id: 10,
+              card_id: 100,
+              card: { name: 'Revenue by Region' },
+              parameter_mappings: [
+                {
+                  parameter_id: 'param-region',
+                  target: ['dimension', ['template-tag', 'region']],
+                },
+              ],
+            },
+          ],
+        })
+      );
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.mode).toBe('discover');
+      expect(responseData.execution_readiness.ready).toBe(false);
+      expect(responseData.execution_readiness.blocking_issues).toHaveLength(1);
+      expect(responseData.execution_readiness.suggested_filter_payload).toEqual({
+        region: ['EMEA'],
+        year: 2025,
+      });
+      expect(responseData.filter_resolution.matched_filter_slugs).toEqual(['region']);
+      expect(responseData.filter_resolution.unmatched_filter_slugs).toEqual(['year']);
+      expect(responseData.filter_mapping_matrix).toHaveLength(2);
+      expect(mockApiClient.request).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Execute mode', () => {
+    it('should fail fast in strict mode when filters are unknown or unmapped', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 3,
+        dashboard_filters: {
+          unknown_filter: 'x',
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 3,
+          name: 'Unknown Filter Dashboard',
+          parameters: [],
+          dashcards: [{ id: 30, card_id: 300, card: { name: 'Card A' }, parameter_mappings: [] }],
+        })
+      );
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow('Dashboard filter validation failed');
+
+      expect(mockApiClient.request).not.toHaveBeenCalled();
+    });
+
+    it('should allow best-effort when strict_filters is false', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 7,
+        strict_filters: false,
+        dashboard_filters: {
+          unknown_filter: 'x',
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 7,
+          name: 'Non Strict Dashboard',
+          parameters: [],
+          dashcards: [{ id: 70, card_id: 700, card: { name: 'Card A' }, parameter_mappings: [] }],
+        })
+      );
+
+      mockApiClient.request.mockResolvedValueOnce({
+        data: {
+          rows: [['ok']],
+          cols: [{ name: 'status' }],
+        },
+      });
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.success).toBe(true);
+      expect(responseData.mode).toBe('execute');
+      expect(responseData.strict_filters).toBe(false);
+      expect(responseData.filter_resolution.unmatched_filter_slugs).toEqual(['unknown_filter']);
+      expect(mockApiClient.request).toHaveBeenCalledTimes(1);
+    });
+
     it('should execute dashboard cards with mapped dashboard filters', async () => {
       const request = createMockRequest('execute_dashboard', {
         dashboard_id: 1,
@@ -191,6 +332,7 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
 
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
+      expect(responseData.mode).toBe('execute');
       expect(responseData.dashboard.id).toBe(1);
       expect(responseData.dashboard.executed_cards).toBe(1);
       expect(responseData.dashboard.skipped_cards).toBe(1);
@@ -300,42 +442,6 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
       expect(responseData.errors).toHaveLength(1);
       expect(responseData.errors[0].card_id).toBe(201);
       expect(responseData.errors[0].error).toContain('Dashboard card execution failed');
-    });
-
-    it('should include warning for unknown dashboard filter slug', async () => {
-      const request = createMockRequest('execute_dashboard', {
-        dashboard_id: 3,
-        dashboard_filters: {
-          unknown_filter: 'x',
-        },
-      });
-      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
-
-      mockApiClient.getDashboard.mockResolvedValueOnce(
-        createCachedResponse({
-          id: 3,
-          name: 'Unknown Filter Dashboard',
-          parameters: [],
-          dashcards: [],
-        })
-      );
-
-      const result = await handleExecuteDashboard(
-        request as any,
-        'test-request-id',
-        mockApiClient as any,
-        logDebug,
-        logInfo,
-        logWarn,
-        logError
-      );
-
-      const responseData = JSON.parse(result.content[0].text);
-      expect(responseData.warnings).toContain(
-        'Dashboard filter "unknown_filter" was not found in dashboard parameters'
-      );
-      expect(responseData.filter_resolution.matched_filter_slugs).toEqual([]);
-      expect(responseData.filter_resolution.unmatched_filter_slugs).toEqual(['unknown_filter']);
     });
 
     it('should pass through array values for dimension mappings', async () => {

--- a/tests/handlers/executeDashboard.test.ts
+++ b/tests/handlers/executeDashboard.test.ts
@@ -102,6 +102,28 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
         )
       ).rejects.toThrow(McpError);
     });
+
+    it('should throw error when dashboard filter array contains invalid values', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 1,
+        dashboard_filters: {
+          region: ['EMEA', ''],
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow(McpError);
+    });
   });
 
   describe('Dashboard execution flow', () => {
@@ -175,7 +197,11 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
       expect(responseData.cards).toHaveLength(1);
       expect(responseData.cards[0].card_id).toBe(100);
       expect(responseData.cards[0].row_count).toBe(2);
+      expect(responseData.cards[0].applied_parameter_count).toBe(1);
+      expect(responseData.cards[0].applied_filters).toEqual(['region']);
       expect(responseData.skipped[0].reason).toContain('non-executable');
+      expect(responseData.filter_resolution.matched_filter_slugs).toEqual(['region']);
+      expect(responseData.filter_resolution.unmatched_filter_slugs).toEqual([]);
 
       expect(mockApiClient.request).toHaveBeenCalledWith(
         '/api/dashboard/1/dashcard/10/card/100/query',
@@ -188,7 +214,7 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
                 slug: 'region',
                 type: 'category',
                 target: ['dimension', ['template-tag', 'region']],
-                value: 'EMEA',
+                value: ['EMEA'],
               },
             ],
             pivot_results: false,
@@ -307,6 +333,82 @@ describe('handleExecuteDashboard (execute_dashboard command)', () => {
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.warnings).toContain(
         'Dashboard filter "unknown_filter" was not found in dashboard parameters'
+      );
+      expect(responseData.filter_resolution.matched_filter_slugs).toEqual([]);
+      expect(responseData.filter_resolution.unmatched_filter_slugs).toEqual(['unknown_filter']);
+    });
+
+    it('should pass through array values for dimension mappings', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 5,
+        dashboard_filters: {
+          facility_name: ['Centro Médico Teknon', 'Clinic B'],
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 5,
+          name: 'Facilities Dashboard',
+          parameters: [
+            {
+              id: 'param-facility',
+              slug: 'facility_name',
+              type: 'category',
+            },
+          ],
+          dashcards: [
+            {
+              id: 50,
+              card_id: 500,
+              card: { name: 'Facilities' },
+              parameter_mappings: [
+                {
+                  parameter_id: 'param-facility',
+                  target: ['dimension', ['template-tag', 'facility_name']],
+                },
+              ],
+            },
+          ],
+        })
+      );
+
+      mockApiClient.request.mockResolvedValueOnce({
+        data: {
+          rows: [['Centro Médico Teknon']],
+          cols: [{ name: 'facility_name' }],
+        },
+      });
+
+      await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      expect(mockApiClient.request).toHaveBeenCalledWith(
+        '/api/dashboard/5/dashcard/50/card/500/query',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            parameters: [
+              {
+                id: 'param-facility',
+                slug: 'facility_name',
+                type: 'category',
+                target: ['dimension', ['template-tag', 'facility_name']],
+                value: ['Centro Médico Teknon', 'Clinic B'],
+              },
+            ],
+            pivot_results: false,
+            format_rows: false,
+          }),
+        })
       );
     });
 

--- a/tests/handlers/executeDashboard.test.ts
+++ b/tests/handlers/executeDashboard.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for the execute_dashboard handler
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { handleExecuteDashboard } from '../../src/handlers/executeDashboard/index.js';
+import { McpError } from '../../src/types/core.js';
+import {
+  createCachedResponse,
+  createMockRequest,
+  getLoggerFunctions,
+  mockApiClient,
+  mockLogger,
+  resetAllMocks,
+} from '../setup.js';
+
+describe('handleExecuteDashboard (execute_dashboard command)', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  describe('Parameter validation', () => {
+    it('should throw error when neither dashboard_id nor dashboard_url is provided', async () => {
+      const request = createMockRequest('execute_dashboard', {});
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        'Missing required parameters: dashboard_id or dashboard_url must be provided',
+        { requestId: 'test-request-id' }
+      );
+    });
+
+    it('should throw error when dashboard_url cannot be parsed', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_url: 'https://metabase.example.com/dashboard/not-a-number',
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow(McpError);
+    });
+
+    it('should throw error when dashboard_filters is not an object', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 1,
+        dashboard_filters: 'invalid',
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow(McpError);
+    });
+
+    it('should throw error when dashboard filter value type is invalid', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 1,
+        dashboard_filters: {
+          region: { invalid: true },
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecuteDashboard(
+          request as any,
+          'test-request-id',
+          mockApiClient as any,
+          logDebug,
+          logInfo,
+          logWarn,
+          logError
+        )
+      ).rejects.toThrow(McpError);
+    });
+  });
+
+  describe('Dashboard execution flow', () => {
+    it('should execute dashboard cards with mapped dashboard filters', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 1,
+        dashboard_filters: {
+          region: 'EMEA',
+        },
+        row_limit: 100,
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 1,
+          name: 'Revenue Dashboard',
+          parameters: [
+            {
+              id: 'param-region',
+              slug: 'region',
+              type: 'category',
+            },
+          ],
+          dashcards: [
+            {
+              id: 10,
+              card_id: 100,
+              card: { name: 'Revenue by Region' },
+              parameter_mappings: [
+                {
+                  parameter_id: 'param-region',
+                  target: ['dimension', ['template-tag', 'region']],
+                },
+              ],
+            },
+            {
+              id: 11,
+              card_id: null,
+              parameter_mappings: [],
+            },
+          ],
+        })
+      );
+
+      mockApiClient.request.mockResolvedValueOnce({
+        data: {
+          rows: [
+            ['EMEA', 1000],
+            ['EMEA', 1200],
+          ],
+          cols: [{ name: 'region' }, { name: 'revenue' }],
+        },
+      });
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.success).toBe(true);
+      expect(responseData.dashboard.id).toBe(1);
+      expect(responseData.dashboard.executed_cards).toBe(1);
+      expect(responseData.dashboard.skipped_cards).toBe(1);
+      expect(responseData.cards).toHaveLength(1);
+      expect(responseData.cards[0].card_id).toBe(100);
+      expect(responseData.cards[0].row_count).toBe(2);
+      expect(responseData.skipped[0].reason).toContain('non-executable');
+
+      expect(mockApiClient.request).toHaveBeenCalledWith(
+        '/api/dashboard/1/dashcard/10/card/100/query',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            parameters: [
+              {
+                id: 'param-region',
+                slug: 'region',
+                type: 'category',
+                target: ['dimension', ['template-tag', 'region']],
+                value: 'EMEA',
+              },
+            ],
+            pivot_results: false,
+            format_rows: false,
+          }),
+        })
+      );
+    });
+
+    it('should parse dashboard_id from dashboard_url', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_url: 'https://metabase.example.com/dashboard/321-my-dashboard',
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 321,
+          name: 'Parsed Dashboard',
+          parameters: [],
+          dashcards: [],
+        })
+      );
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.dashboard.id).toBe(321);
+    });
+
+    it('should continue executing other cards when one fails', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 2,
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 2,
+          name: 'Partial Dashboard',
+          parameters: [],
+          dashcards: [
+            { id: 20, card_id: 200, card: { name: 'Card A' }, parameter_mappings: [] },
+            { id: 21, card_id: 201, card: { name: 'Card B' }, parameter_mappings: [] },
+          ],
+        })
+      );
+
+      mockApiClient.request.mockImplementation((path: string) => {
+        if (path.includes('/dashcard/20/')) {
+          return Promise.resolve({
+            data: {
+              rows: [['ok']],
+              cols: [{ name: 'status' }],
+            },
+          });
+        }
+        return Promise.reject(new Error('query failed'));
+      });
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.success).toBe(true);
+      expect(responseData.dashboard.executed_cards).toBe(1);
+      expect(responseData.dashboard.failed_cards).toBe(1);
+      expect(responseData.errors).toHaveLength(1);
+      expect(responseData.errors[0].card_id).toBe(201);
+      expect(responseData.errors[0].error).toContain('Dashboard card execution failed');
+    });
+
+    it('should include warning for unknown dashboard filter slug', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 3,
+        dashboard_filters: {
+          unknown_filter: 'x',
+        },
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 3,
+          name: 'Unknown Filter Dashboard',
+          parameters: [],
+          dashcards: [],
+        })
+      );
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.warnings).toContain(
+        'Dashboard filter "unknown_filter" was not found in dashboard parameters'
+      );
+    });
+
+    it('should enforce row limits on numbered response format', async () => {
+      const request = createMockRequest('execute_dashboard', {
+        dashboard_id: 4,
+        row_limit: 2,
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getDashboard.mockResolvedValueOnce(
+        createCachedResponse({
+          id: 4,
+          name: 'Numbered Rows Dashboard',
+          parameters: [],
+          dashcards: [
+            { id: 40, card_id: 400, card: { name: 'Card Numbered' }, parameter_mappings: [] },
+          ],
+        })
+      );
+
+      mockApiClient.request.mockResolvedValueOnce({
+        '0': { id: 1 },
+        '1': { id: 2 },
+        '2': { id: 3 },
+        data: { rows_truncated: false },
+      });
+
+      const result = await handleExecuteDashboard(
+        request as any,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.cards[0].original_row_count).toBe(3);
+      expect(responseData.cards[0].row_count).toBe(2);
+      expect(responseData.cards[0].data['2']).toBeUndefined();
+      expect(responseData.cards[0].data['1']).toEqual({ id: 2 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `execute_dashboard` MCP tool for API-first dashboard exploration and execution
- add `mode` support:
  - `discover`: preflight filter/mapping analysis without executing cards
  - `execute` (default): executes dashboard cards after preflight validation
- add strict filter preflight for execute mode (`strict_filters`, default `true` in execute mode)
- add richer diagnostics for filter debugging:
  - `filter_resolution`
  - `filter_mapping_matrix`
  - `execution_readiness` with `blocking_issues` and `suggested_filter_payload`
  - per-card `applied_filters` and `applied_parameter_count`
- support URL query-string filters from `dashboard_url` when `dashboard_filters` is omitted
- relax target-shape validation so valid Metabase mapping targets are not incorrectly rejected
- keep best-effort per-card execution after preflight passes
- include merged dimension-parameter array handling improvements from issue #28 (execute/export validation + normalization)
- update docs/manifest and response references:
  - `docs/responses/execute_dashboard.json`
  - `docs/responses/execute_dashboard_discover.json`

## Validation
- `npm run validate`
- `npm test`
- `npm test -- tests/handlers/executeDashboard.test.ts`

## Notes
- this remains API-only dashboard exploration (no headless UI/browser automation)
- recommended client flow:
  1. call `execute_dashboard` with `mode: "discover"`
  2. reuse `execution_readiness.suggested_filter_payload`
  3. call `execute_dashboard` with `mode: "execute"`
