### PR TITLE
fix: support dimension array values for card filters

### DIFF
--- a/src/handlers/execute/executeCard.ts
+++ b/src/handlers/execute/executeCard.ts
@@ -4,6 +4,7 @@ import {
   validatePositiveInteger,
   validateMetabaseResponse,
   formatJson,
+  normalizeCardParametersForMetabase,
 } from '../../utils/index.js';
 import { CardExecutionParams, ExecutionResponse } from './types.js';
 
@@ -24,9 +25,11 @@ export async function executeCard(
 
   logDebug(`Executing card ID: ${cardId} with row limit: ${rowLimit}`);
 
+  const normalizedCardParameters = normalizeCardParametersForMetabase(cardParameters);
+
   // Build card execution request body
   const cardRequestBody = {
-    parameters: cardParameters,
+    parameters: normalizedCardParameters,
     pivot_results: false,
     format_rows: false,
   };

--- a/src/handlers/export/exportCard.ts
+++ b/src/handlers/export/exportCard.ts
@@ -5,6 +5,7 @@ import {
   analyzeXlsxContent,
   validateMetabaseResponse,
   formatJson,
+  normalizeCardParametersForMetabase,
 } from '../../utils/index.js';
 import { config, authMethod, AuthMethod } from '../../config.js';
 import * as XLSX from 'xlsx';
@@ -96,6 +97,7 @@ export async function exportCard(
   const { cardId, cardParameters, format, filename } = params;
 
   logDebug(`Exporting card ${cardId} in ${format} format`);
+  const normalizedCardParameters = normalizeCardParametersForMetabase(cardParameters);
 
   try {
     // First, fetch the card to get its name for filename purposes
@@ -113,7 +115,8 @@ export async function exportCard(
     const exportEndpoint = `/api/card/${cardId}/query/${format}`;
 
     // Build the request body with parameters if provided
-    const requestBody = cardParameters.length > 0 ? { parameters: cardParameters } : {};
+    const requestBody =
+      normalizedCardParameters.length > 0 ? { parameters: normalizedCardParameters } : {};
 
     // For export endpoints, we need to handle different response types
     const url = new URL(exportEndpoint, config.METABASE_URL);

--- a/src/handlers/prompts/templates/cardExecution.ts
+++ b/src/handlers/prompts/templates/cardExecution.ts
@@ -30,7 +30,7 @@ You must execute this card and return the data. If filter requirements are provi
      "slug": "parameter-slug",
      "target": ["dimension", ["template-tag", "parameter-name"]],
      "type": "parameter-type",
-     "value": "converted-value"
+     "value": ["converted-value"]
    }]
    \`\`\`
    Start with row_limit=100.

--- a/src/handlers/prompts/templates/cardExport.ts
+++ b/src/handlers/prompts/templates/cardExport.ts
@@ -24,7 +24,7 @@ You must export this card data to a file. Follow this simplified, reliable proce
 
 1. **Parse filters** (if provided) against the card's available parameters. Convert natural language values to proper formats (dates to ISO format, numbers to integers/floats, text to strings).
 
-2. **Try card export first** using the 'export' tool in card mode with card_id=${cardId} and format="${fileType}". If filters were identified, include them as card_parameters.
+2. **Try card export first** using the 'export' tool in card mode with card_id=${cardId} and format="${fileType}". If filters were identified, include them as card_parameters. For dimension targets, use array values (e.g., \`"value": ["converted-value"]\`).
 
 3. **Use SQL fallback** if card export fails OR returns 0 results:
    - Extract the native SQL query from the card details above

--- a/src/server.ts
+++ b/src/server.ts
@@ -362,7 +362,7 @@ export class MetabaseServer {
                   type: 'array',
                   items: { type: 'object' },
                   description:
-                    'Parameters for filtering card results (card mode only). Each parameter must follow Metabase format: {id: "uuid", slug: "param_name", target: ["dimension", ["template-tag", "param_name"]], type: "param_type", value: "param_value"}',
+                    'Parameters for filtering card results (card mode only). Each parameter must follow Metabase format: {id: "uuid", slug: "param_name", target: ["dimension", ["template-tag", "param_name"]], type: "param_type", value: ["param_value"]}. For dimension targets, value should be an array; scalar values are accepted and auto-wrapped.',
                 },
                 row_limit: {
                   type: 'number',
@@ -411,7 +411,7 @@ export class MetabaseServer {
                   type: 'array',
                   items: { type: 'object' },
                   description:
-                    'Parameters for filtering card results before export (card mode only). Each parameter must follow Metabase format: {id: "uuid", slug: "param_name", target: ["dimension", ["template-tag", "param_name"]], type: "param_type", value: "param_value"}',
+                    'Parameters for filtering card results before export (card mode only). Each parameter must follow Metabase format: {id: "uuid", slug: "param_name", target: ["dimension", ["template-tag", "param_name"]], type: "param_type", value: ["param_value"]}. For dimension targets, value should be an array; scalar values are accepted and auto-wrapped.',
                 },
                 format: {
                   type: 'string',

--- a/src/utils/parameterValidation.ts
+++ b/src/utils/parameterValidation.ts
@@ -6,7 +6,33 @@ export interface MetabaseCardParameter {
   slug: string;
   target: [string, [string, string]];
   type: string;
-  value: string | number | boolean;
+  value: string | number | boolean | Array<string | number | boolean>;
+}
+
+type PrimitiveCardParameterValue = string | number | boolean;
+
+function isPrimitiveCardParameterValue(value: unknown): value is PrimitiveCardParameterValue {
+  const valueType = typeof value;
+  return valueType === 'string' || valueType === 'number' || valueType === 'boolean';
+}
+
+function isDimensionTarget(target: unknown): boolean {
+  return Array.isArray(target) && target[0] === 'dimension';
+}
+
+export function normalizeCardParametersForMetabase(
+  cardParameters: MetabaseCardParameter[]
+): MetabaseCardParameter[] {
+  return cardParameters.map(param => {
+    if (!isDimensionTarget(param.target) || Array.isArray(param.value)) {
+      return param;
+    }
+
+    return {
+      ...param,
+      value: [param.value],
+    };
+  });
 }
 
 export function validateCardParameters(
@@ -108,9 +134,51 @@ export function validateCardParameters(
       );
     }
 
-    // Validate value field (can be string, number, or boolean)
-    const valueType = typeof param.value;
-    if (valueType !== 'string' && valueType !== 'number' && valueType !== 'boolean') {
+    const dimensionTarget = isDimensionTarget(param.target);
+    const value = param.value;
+
+    if (Array.isArray(value)) {
+      if (!dimensionTarget) {
+        logWarn(
+          `Invalid 'value' field in ${paramIndex}: arrays are only allowed for dimension targets`,
+          { requestId, param }
+        );
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Card parameter at index ${i} has invalid 'value' field: arrays are only allowed for dimension targets`
+        );
+      }
+
+      if (value.length === 0) {
+        logWarn(`Invalid 'value' field in ${paramIndex}: array value cannot be empty`, {
+          requestId,
+          param,
+        });
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Card parameter at index ${i} has invalid 'value' field: array value cannot be empty`
+        );
+      }
+
+      const hasInvalidArrayItem = value.some(
+        item =>
+          !isPrimitiveCardParameterValue(item) || (typeof item === 'string' && item.trim() === '')
+      );
+      if (hasInvalidArrayItem) {
+        logWarn(
+          `Invalid 'value' field in ${paramIndex}: dimension arrays must contain only non-empty string, number, or boolean values`,
+          { requestId, param }
+        );
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Card parameter at index ${i} has invalid 'value' field: dimension arrays must contain only non-empty string, number, or boolean values`
+        );
+      }
+
+      continue;
+    }
+
+    if (!isPrimitiveCardParameterValue(value)) {
       logWarn(`Invalid 'value' field in ${paramIndex}: must be string, number, or boolean`, {
         requestId,
         param,
@@ -121,8 +189,7 @@ export function validateCardParameters(
       );
     }
 
-    // Additional validation for string values (not empty)
-    if (valueType === 'string' && (param.value as string).trim() === '') {
+    if (typeof value === 'string' && value.trim() === '') {
       logWarn(`Invalid 'value' field in ${paramIndex}: string value cannot be empty`, {
         requestId,
         param,

--- a/tests/handlers/execute.test.ts
+++ b/tests/handlers/execute.test.ts
@@ -312,6 +312,119 @@ describe('handleExecute (execute command)', () => {
       expect(responseData.card_id).toBe(1);
     });
 
+    it('should accept dimension value arrays in card_parameters', async () => {
+      const request = createMockRequest('execute', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'b86c100e-87cb-09d6-7c33-e58cd2cdbcb2',
+            slug: 'user_id',
+            target: ['dimension', ['template-tag', 'user_id']],
+            type: 'id',
+            value: ['12345', '67890']
+          }
+        ],
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.request.mockResolvedValueOnce({
+        data: {
+          rows: [['John', 'Doe']],
+          cols: [{ name: 'first_name' }, { name: 'last_name' }],
+        },
+      });
+
+      const result = await handleExecute(
+        request,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      expect(result.content).toHaveLength(1);
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.success).toBe(true);
+      expect(responseData.card_id).toBe(1);
+    });
+
+    it('should throw error when dimension card parameter has empty value array', async () => {
+      const request = createMockRequest('execute', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'test-id',
+            slug: 'test-param',
+            target: ['dimension', ['template-tag', 'test-param']],
+            type: 'text',
+            value: []
+          }
+        ]
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('array value cannot be empty'),
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
+
+    it('should throw error when non-dimension card parameter has array value', async () => {
+      const request = createMockRequest('execute', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'test-id',
+            slug: 'test-param',
+            target: ['variable', ['template-tag', 'test-param']],
+            type: 'text',
+            value: ['test-value']
+          }
+        ]
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('arrays are only allowed for dimension targets'),
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
+
+    it('should throw error when dimension card parameter array contains invalid items', async () => {
+      const request = createMockRequest('execute', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'test-id',
+            slug: 'test-param',
+            target: ['dimension', ['template-tag', 'test-param']],
+            type: 'text',
+            value: ['ok', '']
+          }
+        ]
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExecute(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('dimension arrays must contain only non-empty string, number, or boolean values'),
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
+
     it('should throw error when card_parameters has empty string values', async () => {
       const request = createMockRequest('execute', {
         card_id: 1,
@@ -556,11 +669,18 @@ describe('handleExecute (execute command)', () => {
       expect(mockApiClient.request).toHaveBeenCalledWith('/api/card/123/query/json', {
         method: 'POST',
         body: JSON.stringify({
-          parameters: cardParameters,
+          parameters: [
+            {
+              ...cardParameters[0],
+              value: ['9458014662'],
+            }
+          ],
           pivot_results: false,
           format_rows: false,
         }),
       });
+
+      expect(cardParameters[0].value).toBe('9458014662');
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('text');

--- a/tests/handlers/export.test.ts
+++ b/tests/handlers/export.test.ts
@@ -463,6 +463,127 @@ describe('handleExport (export command)', () => {
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.success).toBe(true);
     });
+
+    it('should accept dimension value arrays in card_parameters for export', async () => {
+      const request = createMockRequest('export', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'b86c100e-87cb-09d6-7c33-e58cd2cdbcb2',
+            slug: 'user_id',
+            target: ['dimension', ['template-tag', 'user_id']],
+            type: 'id',
+            value: ['12345', '67890']
+          }
+        ],
+        format: 'csv'
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getCard.mockResolvedValueOnce({
+        data: { id: 1, name: 'Test Export Card' },
+        source: 'api',
+        fetchTime: 100
+      });
+
+      const csvData = 'id,name\n1,John';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(csvData),
+      });
+
+      const result = await handleExport(
+        request,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      expect(result.content).toHaveLength(1);
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.success).toBe(true);
+    });
+
+    it('should throw error when dimension card parameter has empty value array for export', async () => {
+      const request = createMockRequest('export', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'test-id',
+            slug: 'test-param',
+            target: ['dimension', ['template-tag', 'test-param']],
+            type: 'text',
+            value: []
+          }
+        ],
+        format: 'csv'
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExport(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('array value cannot be empty'),
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
+
+    it('should throw error when non-dimension card parameter has array value for export', async () => {
+      const request = createMockRequest('export', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'test-id',
+            slug: 'test-param',
+            target: ['variable', ['template-tag', 'test-param']],
+            type: 'text',
+            value: ['test-value']
+          }
+        ],
+        format: 'csv'
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExport(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('arrays are only allowed for dimension targets'),
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
+
+    it('should throw error when dimension card parameter array contains invalid items for export', async () => {
+      const request = createMockRequest('export', {
+        card_id: 1,
+        card_parameters: [
+          {
+            id: 'test-id',
+            slug: 'test-param',
+            target: ['dimension', ['template-tag', 'test-param']],
+            type: 'text',
+            value: ['ok', '']
+          }
+        ],
+        format: 'csv'
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      await expect(
+        handleExport(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow(McpError);
+
+      expect(mockLogger.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('dimension arrays must contain only non-empty string, number, or boolean values'),
+        expect.objectContaining({ requestId: 'test-request-id' })
+      );
+    });
   });
 
   describe('Card export mode', () => {
@@ -557,7 +678,7 @@ describe('handleExport (export command)', () => {
                 slug: 'user_id',
                 target: ['dimension', ['template-tag', 'user_id']],
                 type: 'id',
-                value: '42'
+                value: ['42']
               }
             ]
           })


### PR DESCRIPTION
## Summary
- allow `card_parameters[*].value` arrays for dimension targets and validate array contents
- normalize scalar dimension values to single-item arrays before Metabase execute/export requests
- update execute/export tool docs and prompt templates to show dimension array format
- add execute/export tests for normalization and validation edge cases

## Verification
- npm run validate
- npm test -- tests/handlers/execute.test.ts tests/handlers/export.test.ts

Fixes #28
