### PR TITLE
Mask Metabase credentials in logs and honor LOG_LEVEL

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,15 +1,7 @@
-import { config, AuthMethod } from './config.js';
+import { config, AuthMethod, LogLevel } from './config.js';
 import { ErrorCode, McpError, isMcpError } from './types/core.js';
 import { NetworkErrorFactory, createErrorFromHttpResponse } from './utils/errorFactory.js';
-
-// Logger level enum
-enum LogLevel {
-  DEBUG = 'debug',
-  INFO = 'info',
-  WARN = 'warn',
-  ERROR = 'error',
-  FATAL = 'fatal',
-}
+import { isLogLevelEnabled, maskHttpHeadersForLog } from './utils/logging.js';
 
 // Interface for tracking data source in API responses
 export interface CachedResponse<T> {
@@ -89,6 +81,10 @@ export class MetabaseApiClient {
 
   // Enhanced logging utilities
   private log(level: LogLevel, message: string, data?: unknown, error?: Error) {
+    if (!isLogLevelEnabled(level)) {
+      return;
+    }
+
     const timestamp = new Date().toISOString();
 
     const logMessage: Record<string, unknown> = {
@@ -158,7 +154,7 @@ export class MetabaseApiClient {
     }
 
     this.logDebug(`Making request to ${url.toString()}`);
-    this.logDebug(`Using headers: ${JSON.stringify(headers)}`);
+    this.logDebug(`Using headers: ${JSON.stringify(maskHttpHeadersForLog(headers))}`);
 
     // Create abort controller for timeout
     const controller = new AbortController();

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { LogLevel } from './config.js';
+import { isLogLevelEnabled } from './utils/logging.js';
 import { generateRequestId } from './utils/index.js';
 // Note: ApiError and isMcpError removed - errors are caught and returned, not type-checked
 import { MetabaseApiClient } from './api.js';
@@ -69,6 +70,10 @@ export class MetabaseServer {
 
   // Enhanced logging utilities
   private log(level: LogLevel, message: string, data?: unknown, error?: Error) {
+    if (!isLogLevelEnabled(level)) {
+      return;
+    }
+
     const timestamp = new Date().toISOString();
 
     const logMessage: Record<string, unknown> = {

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,0 +1,35 @@
+import { config, LogLevel } from '../config.js';
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  [LogLevel.DEBUG]: 0,
+  [LogLevel.INFO]: 1,
+  [LogLevel.WARN]: 2,
+  [LogLevel.ERROR]: 3,
+  [LogLevel.FATAL]: 4,
+};
+
+/**
+ * Whether a log line at `level` should be emitted for the configured minimum `LOG_LEVEL`.
+ */
+export function isLogLevelEnabled(level: LogLevel): boolean {
+  const threshold =
+    LEVEL_PRIORITY[config.LOG_LEVEL as LogLevel] ?? LEVEL_PRIORITY[LogLevel.INFO];
+  return LEVEL_PRIORITY[level] >= threshold;
+}
+
+const SENSITIVE_HEADER_NAMES = new Set([
+  'x-api-key',
+  'authorization',
+  'x-metabase-session',
+  'cookie',
+  'set-cookie',
+]);
+
+/** Returns a shallow copy of headers with credential values replaced for safe logging. */
+export function maskHttpHeadersForLog(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    out[name] = SENSITIVE_HEADER_NAMES.has(name.toLowerCase()) ? '***' : value;
+  }
+  return out;
+}

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -11,10 +11,14 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
 /**
  * Whether a log line at `level` should be emitted for the configured minimum `LOG_LEVEL`.
  */
-export function isLogLevelEnabled(level: LogLevel): boolean {
-  const threshold =
-    LEVEL_PRIORITY[config.LOG_LEVEL as LogLevel] ?? LEVEL_PRIORITY[LogLevel.INFO];
-  return LEVEL_PRIORITY[level] >= threshold;
+export function isLogLevelEnabled(
+  level: LogLevel,
+  minimumLevel: LogLevel = config.LOG_LEVEL as LogLevel
+): boolean {
+  const levelPriority = LEVEL_PRIORITY[level];
+  const minimumPriority = LEVEL_PRIORITY[minimumLevel] ?? LEVEL_PRIORITY[LogLevel.INFO];
+
+  return levelPriority >= minimumPriority;
 }
 
 const SENSITIVE_HEADER_NAMES = new Set([
@@ -27,9 +31,9 @@ const SENSITIVE_HEADER_NAMES = new Set([
 
 /** Returns a shallow copy of headers with credential values replaced for safe logging. */
 export function maskHttpHeadersForLog(headers: Record<string, string>): Record<string, string> {
-  const out: Record<string, string> = {};
+  const maskedHeaders: Record<string, string> = {};
   for (const [name, value] of Object.entries(headers)) {
-    out[name] = SENSITIVE_HEADER_NAMES.has(name.toLowerCase()) ? '***' : value;
+    maskedHeaders[name] = SENSITIVE_HEADER_NAMES.has(name.toLowerCase()) ? '***' : value;
   }
-  return out;
+  return maskedHeaders;
 }

--- a/tests/utils/logging.test.ts
+++ b/tests/utils/logging.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { maskHttpHeadersForLog } from '../../src/utils/logging.js';
+
+describe('maskHttpHeadersForLog', () => {
+  it('masks API key and session headers case-insensitively by header name', () => {
+    const masked = maskHttpHeadersForLog({
+      'Content-Type': 'application/json',
+      'X-API-KEY': 'secret-key',
+      'X-Metabase-Session': 'session-token',
+      Authorization: 'Bearer token',
+    });
+
+    expect(masked['Content-Type']).toBe('application/json');
+    expect(masked['X-API-KEY']).toBe('***');
+    expect(masked['X-Metabase-Session']).toBe('***');
+    expect(masked.Authorization).toBe('***');
+  });
+});

--- a/tests/utils/logging.test.ts
+++ b/tests/utils/logging.test.ts
@@ -1,18 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { maskHttpHeadersForLog } from '../../src/utils/logging.js';
+import { LogLevel } from '../../src/config.js';
+import { isLogLevelEnabled, maskHttpHeadersForLog } from '../../src/utils/logging.js';
 
-describe('maskHttpHeadersForLog', () => {
+describe('logging utilities', () => {
   it('masks API key and session headers case-insensitively by header name', () => {
-    const masked = maskHttpHeadersForLog({
+    const headers = {
       'Content-Type': 'application/json',
       'X-API-KEY': 'secret-key',
       'X-Metabase-Session': 'session-token',
       Authorization: 'Bearer token',
-    });
+      Cookie: 'sid=secret',
+    };
 
-    expect(masked['Content-Type']).toBe('application/json');
-    expect(masked['X-API-KEY']).toBe('***');
-    expect(masked['X-Metabase-Session']).toBe('***');
-    expect(masked.Authorization).toBe('***');
+    const maskedHeaders = maskHttpHeadersForLog(headers);
+
+    expect(maskedHeaders).toEqual({
+      'Content-Type': 'application/json',
+      'X-API-KEY': '***',
+      'X-Metabase-Session': '***',
+      Authorization: '***',
+      Cookie: '***',
+    });
+    expect(headers['X-API-KEY']).toBe('secret-key');
+  });
+
+  it('honors minimum log level thresholds', () => {
+    expect(isLogLevelEnabled(LogLevel.DEBUG, LogLevel.DEBUG)).toBe(true);
+    expect(isLogLevelEnabled(LogLevel.INFO, LogLevel.DEBUG)).toBe(true);
+    expect(isLogLevelEnabled(LogLevel.DEBUG, LogLevel.ERROR)).toBe(false);
+    expect(isLogLevelEnabled(LogLevel.ERROR, LogLevel.ERROR)).toBe(true);
+    expect(isLogLevelEnabled(LogLevel.FATAL, LogLevel.ERROR)).toBe(true);
+    expect(isLogLevelEnabled(LogLevel.ERROR, LogLevel.FATAL)).toBe(false);
   });
 });


### PR DESCRIPTION
closes #33 
### Context

Operators often ship MCP servers with `LOG_LEVEL=fatal` or `error` to limit stderr noise. The Metabase client was still emitting debug lines that included full HTTP headers, which exposed the Metabase API key (and would have exposed session tokens for password auth). Separately, neither the API client nor the server process consulted `LOG_LEVEL`, so those messages appeared regardless of configuration.

### Summary

This change stops credential-bearing headers from ever appearing in log output by masking them before stringification, and wires both the Metabase HTTP client and the MCP server logger to the configured minimum log level so `LOG_LEVEL` behaves as documented.



### How should this be manually tested?

#### Prepare the environment

- [ ] Build and run the MCP (for example `npm run build:fast && node build/src/index.js`) with valid `METABASE_URL` and `METABASE_API_KEY`, first with `LOG_LEVEL=debug` and confirm stderr shows a "Using headers" line where `X-API-KEY` is shown as `***`, not the real key.
- [ ] Run again with `LOG_LEVEL=fatal` and trigger a Metabase request (for example via a tool call from an MCP client); confirm no debug or info lines appear on stderr from the API client for normal operation.
- [ ] Optionally repeat with session authentication instead of an API key and confirm `X-Metabase-Session` is masked if debug logging is enabled.

<img width="839" height="508" alt="image" src="https://github.com/user-attachments/assets/5c5ea849-5f94-453a-aeab-0b7b38689452" />

