### PR TITLE
[codex] Add proxy authorization header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Add the following to your MCP client configuration:
 
         // Optional (defaults shown)
         "EXPORT_DIRECTORY": "~/Downloads/Metabase",    // Export location
+        "METABASE_PROXY_AUTHORIZATION": "",            // Optional Proxy-Authorization value for IAP, e.g. "Bearer <token>"
         "METABASE_READ_ONLY_MODE": "true",             // Restrict to SELECT queries
         "LOG_LEVEL": "info",                           // debug, info, warn, error, fatal (debug enables pretty JSON)
         "CACHE_TTL_MS": "600000",                      // 10 minutes
@@ -186,6 +187,8 @@ Creates `metabase-mcp-{version}.mcpb` ready for GitHub Releases.
 **Read-Only Mode** is enabled by default (`METABASE_READ_ONLY_MODE=true`), restricting the `execute` tool to SELECT queries only. Write operations (INSERT, UPDATE, DELETE, DROP, etc.) are blocked. Set to `false` to allow write operations.
 
 **Authentication**: API key authentication is recommended over email/password for production use.
+
+**Proxy Authentication**: Set `METABASE_PROXY_AUTHORIZATION` when Metabase is behind a proxy that requires a `Proxy-Authorization` header, such as Google IAP. The value is passed through exactly as provided, for example `Bearer <token>`.
 
 ## License
 

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
       "env": {
         "METABASE_URL": "${user_config.metabase_url}",
         "METABASE_API_KEY": "${user_config.metabase_api_key}",
+        "METABASE_PROXY_AUTHORIZATION": "${user_config.metabase_proxy_authorization}",
         "METABASE_USER_EMAIL": "${user_config.metabase_user_email}",
         "METABASE_PASSWORD": "${user_config.metabase_password}",
         "EXPORT_DIRECTORY": "${user_config.export_directory}",
@@ -83,6 +84,14 @@
       "type": "string",
       "title": "API Key",
       "description": "Metabase API Key. Leave empty for email/password authentication.",
+      "required": false,
+      "sensitive": true,
+      "default": ""
+    },
+    "metabase_proxy_authorization": {
+      "type": "string",
+      "title": "Proxy Authorization",
+      "description": "Optional Proxy-Authorization header value for proxy authentication such as Google IAP. Example: Bearer <token>.",
       "required": false,
       "sensitive": true,
       "default": ""

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,6 @@
       "env": {
         "METABASE_URL": "${user_config.metabase_url}",
         "METABASE_API_KEY": "${user_config.metabase_api_key}",
-        "METABASE_PROXY_AUTHORIZATION": "${user_config.metabase_proxy_authorization}",
         "METABASE_USER_EMAIL": "${user_config.metabase_user_email}",
         "METABASE_PASSWORD": "${user_config.metabase_password}",
         "EXPORT_DIRECTORY": "${user_config.export_directory}",
@@ -84,14 +83,6 @@
       "type": "string",
       "title": "API Key",
       "description": "Metabase API Key. Leave empty for email/password authentication.",
-      "required": false,
-      "sensitive": true,
-      "default": ""
-    },
-    "metabase_proxy_authorization": {
-      "type": "string",
-      "title": "Proxy Authorization",
-      "description": "Optional Proxy-Authorization header value for proxy authentication such as Google IAP. Example: Bearer <token>.",
       "required": false,
       "sensitive": true,
       "default": ""

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,6 +2,7 @@ import { config, AuthMethod, LogLevel } from './config.js';
 import { ErrorCode, McpError, isMcpError } from './types/core.js';
 import { NetworkErrorFactory, createErrorFromHttpResponse } from './utils/errorFactory.js';
 import { isLogLevelEnabled, maskHttpHeadersForLog } from './utils/logging.js';
+import { buildMetabaseHeaders } from './utils/requestUtils.js';
 
 // Interface for tracking data source in API responses
 export interface CachedResponse<T> {
@@ -143,15 +144,13 @@ export class MetabaseApiClient {
    */
   async request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const url = new URL(path, this.baseUrl);
-    const headers = { ...this.headers };
-
-    // Add appropriate authentication headers based on the method
-    if (this.authMethod === AuthMethod.API_KEY && this.apiKey) {
-      // Use X-API-KEY header as specified in the Metabase documentation
-      headers['X-API-KEY'] = this.apiKey;
-    } else if (this.authMethod === AuthMethod.SESSION && this.sessionToken) {
-      headers['X-Metabase-Session'] = this.sessionToken;
-    }
+    const headers = buildMetabaseHeaders({
+      baseHeaders: this.headers,
+      authMethod: this.authMethod,
+      apiKey: this.apiKey,
+      sessionToken: this.sessionToken,
+      proxyAuthorization: config.METABASE_PROXY_AUTHORIZATION,
+    });
 
     this.logDebug(`Making request to ${url.toString()}`);
     this.logDebug(`Using headers: ${JSON.stringify(maskHttpHeadersForLog(headers))}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ const envSchema = z
   .object({
     METABASE_URL: z.string().url('METABASE_URL must be a valid URL'),
     METABASE_API_KEY: z.string().optional(),
+    METABASE_PROXY_AUTHORIZATION: z.string().optional(),
     METABASE_USER_EMAIL: z.string().email().optional(),
     METABASE_PASSWORD: z.string().min(1).optional(),
     NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
@@ -77,6 +78,7 @@ function createTestConfig() {
   return {
     METABASE_URL: 'http://localhost:3000',
     METABASE_API_KEY: 'test-api-key',
+    METABASE_PROXY_AUTHORIZATION: undefined,
     METABASE_USER_EMAIL: undefined,
     METABASE_PASSWORD: undefined,
     NODE_ENV: 'test' as const,

--- a/src/handlers/export/exportCard.ts
+++ b/src/handlers/export/exportCard.ts
@@ -6,8 +6,9 @@ import {
   validateMetabaseResponse,
   formatJson,
   normalizeCardParametersForMetabase,
+  buildMetabaseHeaders,
 } from '../../utils/index.js';
-import { config, authMethod, AuthMethod } from '../../config.js';
+import { config, authMethod } from '../../config.js';
 import * as XLSX from 'xlsx';
 import { CardExportParams, ExportResponse } from './types.js';
 import * as fs from 'fs';
@@ -120,16 +121,15 @@ export async function exportCard(
 
     // For export endpoints, we need to handle different response types
     const url = new URL(exportEndpoint, config.METABASE_URL);
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    // Add appropriate authentication headers
-    if (authMethod === AuthMethod.API_KEY && config.METABASE_API_KEY) {
-      headers['X-API-KEY'] = config.METABASE_API_KEY;
-    } else if (authMethod === AuthMethod.SESSION && apiClient.sessionToken) {
-      headers['X-Metabase-Session'] = apiClient.sessionToken;
-    }
+    const headers = buildMetabaseHeaders({
+      baseHeaders: {
+        'Content-Type': 'application/json',
+      },
+      authMethod,
+      apiKey: config.METABASE_API_KEY,
+      sessionToken: apiClient.sessionToken,
+      proxyAuthorization: config.METABASE_PROXY_AUTHORIZATION,
+    });
 
     const response = await fetch(url.toString(), {
       method: 'POST',

--- a/src/handlers/export/exportQuery.ts
+++ b/src/handlers/export/exportQuery.ts
@@ -5,8 +5,9 @@ import {
   analyzeXlsxContent,
   validateMetabaseResponse,
   formatJson,
+  buildMetabaseHeaders,
 } from '../../utils/index.js';
-import { config, authMethod, AuthMethod } from '../../config.js';
+import { config, authMethod } from '../../config.js';
 import * as XLSX from 'xlsx';
 import { SqlExportParams, ExportResponse } from './types.js';
 import * as fs from 'fs';
@@ -122,16 +123,15 @@ export async function exportSqlQuery(
 
     // For export endpoints, we need to handle different response types
     const url = new URL(exportEndpoint, config.METABASE_URL);
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    // Add appropriate authentication headers
-    if (authMethod === AuthMethod.API_KEY && config.METABASE_API_KEY) {
-      headers['X-API-KEY'] = config.METABASE_API_KEY;
-    } else if (authMethod === AuthMethod.SESSION && apiClient.sessionToken) {
-      headers['X-Metabase-Session'] = apiClient.sessionToken;
-    }
+    const headers = buildMetabaseHeaders({
+      baseHeaders: {
+        'Content-Type': 'application/json',
+      },
+      authMethod,
+      apiKey: config.METABASE_API_KEY,
+      sessionToken: apiClient.sessionToken,
+      proxyAuthorization: config.METABASE_PROXY_AUTHORIZATION,
+    });
 
     const response = await fetch(url.toString(), {
       method: 'POST',

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -24,6 +24,7 @@ export function isLogLevelEnabled(
 const SENSITIVE_HEADER_NAMES = new Set([
   'x-api-key',
   'authorization',
+  'proxy-authorization',
   'x-metabase-session',
   'cookie',
   'set-cookie',

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -2,9 +2,35 @@
  * Request handling utilities for the Metabase MCP server.
  */
 
+import { AuthMethod } from '../config.js';
+
 /**
  * Generate a unique request ID
  */
 export function generateRequestId(): string {
   return Math.random().toString(36).substring(2, 15);
+}
+
+interface MetabaseHeaderOptions {
+  baseHeaders?: Record<string, string>;
+  authMethod: AuthMethod;
+  apiKey?: string | null;
+  sessionToken?: string | null;
+  proxyAuthorization?: string | null;
+}
+
+export function buildMetabaseHeaders(options: MetabaseHeaderOptions): Record<string, string> {
+  const headers = { ...(options.baseHeaders ?? {}) };
+
+  if (options.proxyAuthorization) {
+    headers['Proxy-Authorization'] = options.proxyAuthorization;
+  }
+
+  if (options.authMethod === AuthMethod.API_KEY && options.apiKey) {
+    headers['X-API-KEY'] = options.apiKey;
+  } else if (options.authMethod === AuthMethod.SESSION && options.sessionToken) {
+    headers['X-Metabase-Session'] = options.sessionToken;
+  }
+
+  return headers;
 }

--- a/tests/handlers/export.test.ts
+++ b/tests/handlers/export.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { handleExport } from '../../src/handlers/export/index.js';
 import { McpError } from '../../src/types/core.js';
+import { config } from '../../src/config.js';
 import {
   mockApiClient,
   mockLogger,
@@ -64,6 +65,7 @@ describe('handleExport (export command)', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
     vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    config.METABASE_PROXY_AUTHORIZATION = undefined;
   });
 
   describe('Parameter validation', () => {
@@ -277,6 +279,41 @@ describe('handleExport (export command)', () => {
       expect(responseData.success).toBe(true);
       expect(responseData.row_count).toBe(2);
       expect(responseData.file_path).toContain('.json');
+    });
+
+    it('should include proxy authorization header when exporting SQL query', async () => {
+      config.METABASE_PROXY_AUTHORIZATION = 'Bearer iap-token';
+
+      const request = createMockRequest('export', {
+        database_id: 1,
+        query: 'SELECT * FROM users',
+        format: 'csv'
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('id,name\n1,John'),
+      });
+
+      await handleExport(
+        request,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/dataset/csv'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Proxy-Authorization': 'Bearer iap-token',
+          }),
+        })
+      );
     });
 
     it('should export SQL query in XLSX format successfully', async () => {
@@ -682,6 +719,46 @@ describe('handleExport (export command)', () => {
               }
             ]
           })
+        })
+      );
+    });
+
+    it('should include proxy authorization header when exporting card', async () => {
+      config.METABASE_PROXY_AUTHORIZATION = 'Bearer iap-token';
+
+      const request = createMockRequest('export', {
+        card_id: 123,
+        format: 'csv'
+      });
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+
+      mockApiClient.getCard.mockResolvedValueOnce({
+        data: { id: 123, name: 'User Report' },
+        source: 'api',
+        fetchTime: 100
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('id,name\n1,John'),
+      });
+
+      await handleExport(
+        request,
+        'test-request-id',
+        mockApiClient as any,
+        logDebug,
+        logInfo,
+        logWarn,
+        logError
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/card/123/query/csv'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Proxy-Authorization': 'Bearer iap-token',
+          }),
         })
       );
     });

--- a/tests/utils/logging.test.ts
+++ b/tests/utils/logging.test.ts
@@ -9,6 +9,7 @@ describe('logging utilities', () => {
       'X-API-KEY': 'secret-key',
       'X-Metabase-Session': 'session-token',
       Authorization: 'Bearer token',
+      'Proxy-Authorization': 'Bearer iap-token',
       Cookie: 'sid=secret',
     };
 
@@ -19,6 +20,7 @@ describe('logging utilities', () => {
       'X-API-KEY': '***',
       'X-Metabase-Session': '***',
       Authorization: '***',
+      'Proxy-Authorization': '***',
       Cookie: '***',
     });
     expect(headers['X-API-KEY']).toBe('secret-key');

--- a/tests/utils/requestUtils.test.ts
+++ b/tests/utils/requestUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { AuthMethod } from '../../src/config.js';
+import { buildMetabaseHeaders } from '../../src/utils/requestUtils.js';
+
+describe('requestUtils', () => {
+  describe('buildMetabaseHeaders', () => {
+    it('should include API key auth and proxy auth when provided', () => {
+      const headers = buildMetabaseHeaders({
+        baseHeaders: {
+          'Content-Type': 'application/json',
+        },
+        authMethod: AuthMethod.API_KEY,
+        apiKey: 'metabase-api-key',
+        proxyAuthorization: 'Bearer iap-token',
+      });
+
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        'Proxy-Authorization': 'Bearer iap-token',
+        'X-API-KEY': 'metabase-api-key',
+      });
+    });
+
+    it('should include session auth without proxy auth when proxy auth is not configured', () => {
+      const headers = buildMetabaseHeaders({
+        baseHeaders: {
+          'Content-Type': 'application/json',
+        },
+        authMethod: AuthMethod.SESSION,
+        sessionToken: 'session-token',
+      });
+
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        'X-Metabase-Session': 'session-token',
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
## Summary

Adds optional `METABASE_PROXY_AUTHORIZATION` support for Metabase deployments behind Google IAP or similar proxies when configured through environment variables, such as `npx` or manual MCP server usage.

## Changes

- Adds optional proxy authorization config for runtime environment usage.
- Centralizes Metabase header construction for standard API requests and export requests.
- Masks `Proxy-Authorization` in debug header logs.
- Documents the new environment variable and adds focused tests for header propagation.
- Keeps the advanced proxy field out of the MCPB installer configuration for now.

## Validation

- `npm run validate`
- `npm test`
- pre-commit hook reran type-check, lint, format check, and tests

Closes #25