### PR TITLE
fix: normalize numeric tool arguments

### DIFF
--- a/src/handlers/execute/index.ts
+++ b/src/handlers/execute/index.ts
@@ -32,7 +32,7 @@ export async function handleExecute(
   const nativeParameters = Array.isArray(args?.native_parameters) ? args.native_parameters : [];
   const cardParameters = Array.isArray(args?.card_parameters) ? args.card_parameters : [];
   const rowLimitArg = args?.row_limit;
-  const rowLimit = typeof rowLimitArg === 'number' ? rowLimitArg : 100;
+  const rowLimit = rowLimitArg ?? 100;
 
   // First validate that parameter types are correct
   if (cardId !== undefined && typeof cardId !== 'number') {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 const VERSION = '1.1.6';
 import {
+  CallToolRequest,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
   CallToolRequestSchema,
@@ -13,7 +14,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { LogLevel } from './config.js';
 import { isLogLevelEnabled } from './utils/logging.js';
-import { generateRequestId } from './utils/index.js';
+import { generateRequestId, normalizeToolArguments } from './utils/index.js';
 // Note: ApiError and isMcpError removed - errors are caught and returned, not type-checked
 import { MetabaseApiClient } from './api.js';
 import {
@@ -491,10 +492,10 @@ export class MetabaseServer {
       // Helper to wrap handler calls and convert errors to tool results
       // Handles both sync and async handlers
       const safeCall = async <T>(
-        handler: () => T | Promise<T>
+        handler: (normalizedRequest: CallToolRequest) => T | Promise<T>
       ): Promise<T | { content: { type: string; text: string }[]; isError: true }> => {
         try {
-          return await handler();
+          return await handler(normalizeToolArguments(request));
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           this.logError(`Tool execution failed: ${errorMessage}`, error);
@@ -507,9 +508,9 @@ export class MetabaseServer {
 
       switch (request.params?.name) {
         case 'search':
-          return safeCall(() =>
+          return safeCall(normalizedRequest =>
             handleSearch(
-              request,
+              normalizedRequest,
               requestId,
               this.apiClient,
               this.logDebug.bind(this),
@@ -520,9 +521,9 @@ export class MetabaseServer {
           );
 
         case 'list':
-          return safeCall(() =>
+          return safeCall(normalizedRequest =>
             handleList(
-              request,
+              normalizedRequest,
               requestId,
               this.apiClient,
               this.logDebug.bind(this),
@@ -533,9 +534,9 @@ export class MetabaseServer {
           );
 
         case 'execute':
-          return safeCall(() =>
+          return safeCall(normalizedRequest =>
             handleExecute(
-              request,
+              normalizedRequest,
               requestId,
               this.apiClient,
               this.logDebug.bind(this),
@@ -546,9 +547,9 @@ export class MetabaseServer {
           );
 
         case 'export':
-          return safeCall(() =>
+          return safeCall(normalizedRequest =>
             handleExport(
-              request,
+              normalizedRequest,
               requestId,
               this.apiClient,
               this.logDebug.bind(this),
@@ -559,9 +560,9 @@ export class MetabaseServer {
           );
 
         case 'clear_cache':
-          return safeCall(() =>
+          return safeCall(normalizedRequest =>
             handleClearCache(
-              request,
+              normalizedRequest,
               this.apiClient,
               this.logInfo.bind(this),
               this.logWarn.bind(this),
@@ -570,9 +571,9 @@ export class MetabaseServer {
           );
 
         case 'retrieve':
-          return safeCall(() =>
+          return safeCall(normalizedRequest =>
             handleRetrieve(
-              request,
+              normalizedRequest,
               requestId,
               this.apiClient,
               this.logDebug.bind(this),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,5 +17,8 @@ export * from './fileUtils.js';
 // Request utilities
 export * from './requestUtils.js';
 
+// Tool argument normalization
+export * from './toolArguments.js';
+
 // JSON formatting
 export * from './jsonFormatting.js';

--- a/src/utils/toolArguments.ts
+++ b/src/utils/toolArguments.ts
@@ -1,0 +1,91 @@
+import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError } from '../types/core.js';
+
+interface NumericArgumentConfig {
+  scalar?: readonly string[];
+  array?: readonly string[];
+}
+
+const NUMERIC_ARGUMENTS_BY_TOOL: Record<string, NumericArgumentConfig> = {
+  search: {
+    scalar: ['max_results', 'database_id'],
+    array: ['ids'],
+  },
+  retrieve: {
+    scalar: ['table_offset', 'table_limit'],
+    array: ['ids'],
+  },
+  list: {
+    scalar: ['offset', 'limit'],
+  },
+  execute: {
+    scalar: ['database_id', 'card_id', 'row_limit'],
+  },
+  export: {
+    scalar: ['database_id', 'card_id'],
+  },
+};
+
+const INTEGER_STRING_PATTERN = /^-?\d+$/;
+
+function normalizeInteger(value: unknown, path: string): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, `${path} must be an integer`);
+  }
+
+  const normalizedValue = value.trim();
+  if (!INTEGER_STRING_PATTERN.test(normalizedValue)) {
+    throw new McpError(ErrorCode.InvalidParams, `${path} must be an integer`);
+  }
+
+  const numericValue = Number(normalizedValue);
+  if (!Number.isSafeInteger(numericValue)) {
+    throw new McpError(ErrorCode.InvalidParams, `${path} must be a safe integer`);
+  }
+
+  return numericValue;
+}
+
+export function normalizeToolArguments(request: CallToolRequest): CallToolRequest {
+  const config = NUMERIC_ARGUMENTS_BY_TOOL[request.params.name];
+  const args = request.params.arguments;
+
+  if (!config || !args) {
+    return request;
+  }
+
+  const normalizedArguments = { ...args };
+
+  for (const field of config.scalar || []) {
+    if (normalizedArguments[field] !== undefined) {
+      normalizedArguments[field] = normalizeInteger(normalizedArguments[field], field);
+    }
+  }
+
+  for (const field of config.array || []) {
+    const value = normalizedArguments[field];
+    if (value === undefined) {
+      continue;
+    }
+
+    if (!Array.isArray(value)) {
+      throw new McpError(ErrorCode.InvalidParams, `${field} must be an array of integers`);
+    }
+
+    normalizedArguments[field] = value.map((item, index) =>
+      normalizeInteger(item, `${field}[${index}]`)
+    );
+  }
+
+  return {
+    ...request,
+    params: {
+      ...request.params,
+      arguments: normalizedArguments,
+    },
+  };
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -4,6 +4,8 @@
 
 import { ErrorCode, McpError } from '../types/core.js';
 
+const INTEGER_STRING_PATTERN = /^-?\d+$/;
+
 /**
  * Validate positive integer with detailed error message
  */
@@ -41,11 +43,12 @@ export function parseAndValidatePositiveInteger(
   // Try to coerce to number if it's a string
   let numValue: number;
   if (typeof value === 'string') {
-    numValue = parseInt(value, 10);
-    if (isNaN(numValue)) {
+    const normalizedValue = value.trim();
+    if (!INTEGER_STRING_PATTERN.test(normalizedValue)) {
       logWarn(`Invalid ${fieldName} parameter - cannot parse as number`, { requestId, value });
       throw new McpError(ErrorCode.InvalidParams, `${fieldName} must be a number`);
     }
+    numValue = Number(normalizedValue);
   } else if (typeof value === 'number') {
     numValue = value;
   } else {
@@ -78,11 +81,12 @@ export function parseAndValidateNonNegativeInteger(
   // Try to coerce to number if it's a string
   let numValue: number;
   if (typeof value === 'string') {
-    numValue = parseInt(value, 10);
-    if (isNaN(numValue)) {
+    const normalizedValue = value.trim();
+    if (!INTEGER_STRING_PATTERN.test(normalizedValue)) {
       logWarn(`Invalid ${fieldName} parameter - cannot parse as number`, { requestId, value });
       throw new McpError(ErrorCode.InvalidParams, `${fieldName} must be a number`);
     }
+    numValue = Number(normalizedValue);
   } else if (typeof value === 'number') {
     numValue = value;
   } else {

--- a/tests/handlers/list.test.ts
+++ b/tests/handlers/list.test.ts
@@ -458,5 +458,17 @@ describe('handleList', () => {
         handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
       ).rejects.toThrow('limit must be a number');
     });
+
+    it('should reject partially numeric pagination strings', async () => {
+      const [logDebug, logInfo, logWarn, logError] = getLoggerFunctions();
+      const request = createMockRequest('list', {
+        model: 'cards',
+        offset: '12px',
+      });
+
+      await expect(
+        handleList(request, 'test-request-id', mockApiClient as any, logDebug, logInfo, logWarn, logError)
+      ).rejects.toThrow('offset must be a number');
+    });
   });
 });

--- a/tests/utils/toolArguments.test.ts
+++ b/tests/utils/toolArguments.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { normalizeToolArguments } from '../../src/utils/toolArguments.js';
+
+function createRequest(name: string, args: Record<string, unknown>): CallToolRequest {
+  return {
+    method: 'tools/call',
+    params: {
+      name,
+      arguments: args,
+    },
+  };
+}
+
+describe('normalizeToolArguments', () => {
+  it.each([
+    ['search', { max_results: '20', database_id: '3' }, { max_results: 20, database_id: 3 }],
+    ['retrieve', { table_offset: '0', table_limit: '50' }, { table_offset: 0, table_limit: 50 }],
+    ['list', { offset: '10', limit: '100' }, { offset: 10, limit: 100 }],
+    ['execute', { database_id: '4', row_limit: '250' }, { database_id: 4, row_limit: 250 }],
+    ['export', { card_id: '12' }, { card_id: 12 }],
+  ])('normalizes numeric strings for %s', (name, args, expected) => {
+    const request = createRequest(name, args);
+
+    const normalizedRequest = normalizeToolArguments(request);
+
+    expect(normalizedRequest.params.arguments).toEqual(expected);
+    expect(request.params.arguments).toEqual(args);
+  });
+
+  it.each(['search', 'retrieve'])('normalizes numeric strings in %s ids arrays', name => {
+    const normalizedRequest = normalizeToolArguments(createRequest(name, { ids: ['1', 2, '003'] }));
+
+    expect(normalizedRequest.params.arguments?.ids).toEqual([1, 2, 3]);
+  });
+
+  it('leaves native numbers and unrelated arguments unchanged', () => {
+    const request = createRequest('execute', {
+      card_id: 42,
+      row_limit: 100,
+      card_parameters: [{ value: '7' }],
+    });
+
+    expect(normalizeToolArguments(request).params.arguments).toEqual(request.params.arguments);
+  });
+
+  it.each([
+    ['', 'database_id'],
+    ['   ', 'database_id'],
+    ['12px', 'database_id'],
+    ['1.5', 'database_id'],
+    ['1e3', 'database_id'],
+    [null, 'database_id'],
+    [true, 'database_id'],
+  ])('rejects ambiguous scalar value %j', (value, field) => {
+    expect(() => normalizeToolArguments(createRequest('execute', { [field]: value }))).toThrow(
+      `${field} must be an integer`
+    );
+  });
+
+  it('rejects unsafe integer strings', () => {
+    expect(() =>
+      normalizeToolArguments(
+        createRequest('execute', { database_id: `${Number.MAX_SAFE_INTEGER}0` })
+      )
+    ).toThrow('database_id must be a safe integer');
+  });
+
+  it('reports the array element path for invalid IDs', () => {
+    expect(() =>
+      normalizeToolArguments(createRequest('retrieve', { ids: ['1', 'invalid'] }))
+    ).toThrow('ids[1] must be an integer');
+  });
+
+  it('rejects non-array IDs', () => {
+    expect(() => normalizeToolArguments(createRequest('search', { ids: '1' }))).toThrow(
+      'ids must be an array of integers'
+    );
+  });
+
+  it('does not normalize unknown tools', () => {
+    const request = createRequest('unknown', { database_id: '1' });
+
+    expect(normalizeToolArguments(request)).toBe(request);
+  });
+});


### PR DESCRIPTION
## Summary

Normalize schema-declared integer strings before dispatching MCP tool calls to handlers.

- cover scalar numeric arguments across search, retrieve, list, execute, and export
- normalize numeric values inside search and retrieve ID arrays
- reject empty, partial, decimal, non-finite, and non-numeric inputs with path-specific errors
- preserve explicit string row limits instead of silently falling back to the default
- replace permissive pagination parsing that accepted values such as `12px`

## Root cause

Some MCP clients send schema-declared numeric arguments as strings. The low-level server request schema accepts tool arguments as unknown values, while the handlers expect JavaScript numbers and reject those requests.

## Impact

Claude Desktop and other clients that serialize integer arguments as strings can call the affected tools without weakening validation for malformed values.

## Validation

- `npm run build`
- 12 test files passed
- 313 tests passed

Fixes #38